### PR TITLE
Run software TPG on all channels; fix channel numbering bug

### DIFF
--- a/include/fdreadoutlibs/wib/WIBFrameProcessor.hpp
+++ b/include/fdreadoutlibs/wib/WIBFrameProcessor.hpp
@@ -445,7 +445,22 @@ protected:
       m_slot_no = wfptr->get_wib_header()->slot_no;
 
       TLOG() << "Got first item, fiber/crate/slot=" << m_fiber_no << "/" << m_crate_no << "/" << m_slot_no;
-    }
+
+      std::stringstream ss;
+      ss << "Collection channels are:\n";
+      for(size_t i=0; i<swtpg::COLLECTION_REGISTERS_PER_FRAME*swtpg::SAMPLES_PER_REGISTER; ++i){
+        ss << i << "\t" << m_register_channel_map.collection[i] << "\n";
+      }
+      TLOG_DEBUG(2) << ss.str();
+
+      std::stringstream ss2;
+      ss2 << "Induction channels are:\n";
+      for(size_t i=0; i<swtpg::INDUCTION_REGISTERS_PER_FRAME*swtpg::SAMPLES_PER_REGISTER; ++i){
+        ss2 << i << "\t" << m_register_channel_map.induction[i] << "\n";
+      }
+      TLOG_DEBUG(2) << ss2.str();
+
+    } // end if (m_first_coll)
 
     // Signal to the induction thread that there's an item ready
     m_induction_item_to_process = &ind_item;

--- a/include/fdreadoutlibs/wib/WIBFrameProcessor.hpp
+++ b/include/fdreadoutlibs/wib/WIBFrameProcessor.hpp
@@ -210,7 +210,7 @@ public:
       auto runtime = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - m_t0).count();
       TLOG() << "Ran for " << runtime << "ms. Found " << m_num_hits_coll << " collection hits and " << m_num_hits_ind << " induction hits";
     }
-    
+
   }
 
   void init(const nlohmann::json& args) override
@@ -242,7 +242,7 @@ public:
       m_sw_tpg_enabled = true;
 
       m_channel_map = dunedaq::detchannelmaps::make_map(config.channel_map_name);
-            
+
       m_tphandler.reset(
         new WIBTPHandler(*m_tp_sink, *m_tpset_sink, config.tp_timeout, config.tpset_window_size, m_geoid));
 
@@ -437,7 +437,7 @@ protected:
 
     if (m_first_coll) {
       m_register_channel_map = swtpg::get_register_to_offline_channel_map(wfptr, m_channel_map);
-      
+
       m_coll_tpg_pi->setState(collection_registers);
 
       m_fiber_no = wfptr->get_wib_header()->fiber_no;
@@ -494,11 +494,11 @@ protected:
     m_ind_tpg_pi->input = &induction_item_to_process->registers;
     *m_ind_primfind_dest = swtpg::MAGIC;
     swtpg::process_window_avx2(*m_ind_tpg_pi);
-    
+
     m_first_ind = false;
-    
+
   }
-  
+
   // Stage: induction hit finding port
   void find_induction_hits_thread()
   {
@@ -520,13 +520,13 @@ protected:
         // buffering and can relax the latency requirement, but then
         // we would have to think carefully about how we pass hits to
         // m_tp_handler. So we do it this way and spin-wait
-        
+
         // std::this_thread::sleep_for(std::chrono::microseconds(1));
         _mm_pause();
         if(!m_run_marker.load()) break;
       }
       if(!m_run_marker.load()) break;
-      
+
       find_induction_hits(m_induction_item_to_process);
 
       // Signal back to the collection thread that we're done
@@ -635,13 +635,13 @@ protected:
 
     return nhits;
   }
-  
+
 private:
   bool m_sw_tpg_enabled;
 
   InductionItemToProcess* m_induction_item_to_process;
   std::atomic<bool> m_induction_item_ready{false};
-  
+
   size_t m_num_msg = 0;
   size_t m_num_push_fail = 0;
 
@@ -697,7 +697,7 @@ private:
   int16_t* m_ind_taps_p;
   std::unique_ptr<swtpg::ProcessingInfo<swtpg::INDUCTION_REGISTERS_PER_FRAME>> m_ind_tpg_pi;
   std::thread m_induction_thread;
-  
+
   std::unique_ptr<appfwk::DAQSink<types::SW_WIB_TRIGGERPRIMITIVE_STRUCT>> m_tp_sink;
   std::unique_ptr<appfwk::DAQSink<trigger::TPSet>> m_tpset_sink;
   std::unique_ptr<appfwk::DAQSink<detdataformats::wib::WIBFrame>> m_err_frame_sink;

--- a/include/fdreadoutlibs/wib/WIBFrameProcessor.hpp
+++ b/include/fdreadoutlibs/wib/WIBFrameProcessor.hpp
@@ -615,8 +615,6 @@ protected:
           //
           // TLOG() << "Hit: " << hit_start << " " << offline_channel;
 
-          // if (should_send) {
-          //
           triggeralgs::TriggerPrimitive trigprim;
           trigprim.time_start = tp_t_begin;
           trigprim.time_peak = (tp_t_begin + tp_t_end) / 2;
@@ -639,9 +637,6 @@ protected:
             m_tps_dropped++;
           }
 
-          //} else {
-
-          //}
           m_new_tps++;
           ++nhits;
         }

--- a/include/fdreadoutlibs/wib/WIBFrameProcessor.hpp
+++ b/include/fdreadoutlibs/wib/WIBFrameProcessor.hpp
@@ -491,6 +491,7 @@ protected:
     // each superchunk. It appears that anything that makes a system
     // call or puts the thread to sleep causes too much latency
     while (m_induction_item_ready.load()) {
+      _mm_pause();
       // std::this_thread::sleep_for(std::chrono::microseconds(100));
     }
 
@@ -517,7 +518,9 @@ protected:
   // Stage: induction hit finding port
   void find_induction_hits_thread()
   {
-    pthread_setname_np(pthread_self(), "find-ind-hits");
+    std::stringstream thread_name;
+    thread_name << "ind-hits-" << m_geoid.region_id << "-" << m_geoid.element_id;
+    pthread_setname_np(pthread_self(), thread_name.str().c_str());
 
     size_t n_items=0;
     while (m_run_marker.load()) {

--- a/include/fdreadoutlibs/wib/tpg/FrameExpand.hpp
+++ b/include/fdreadoutlibs/wib/tpg/FrameExpand.hpp
@@ -101,11 +101,11 @@ private:
   alignas(32) uint16_t __restrict__ m_array[N * 16]; // NOLINT(build/unsigned)
 };
 
-typedef RegisterArray<6> FrameRegistersCollection;
-typedef RegisterArray<10> FrameRegistersInduction;
+typedef RegisterArray<COLLECTION_REGISTERS_PER_FRAME> FrameRegistersCollection;
+typedef RegisterArray<INDUCTION_REGISTERS_PER_FRAME> FrameRegistersInduction;
 
-typedef RegisterArray<6 * FRAMES_PER_MSG> MessageRegistersCollection;
-typedef RegisterArray<10 * FRAMES_PER_MSG> MessageRegistersInduction;
+typedef RegisterArray<COLLECTION_REGISTERS_PER_FRAME * FRAMES_PER_MSG> MessageRegistersCollection;
+typedef RegisterArray<INDUCTION_REGISTERS_PER_FRAME * FRAMES_PER_MSG> MessageRegistersInduction;
 
 struct FrameRegisters
 {
@@ -476,7 +476,7 @@ get_block_all_adcs(const dunedaq::detdataformats::wib::ColdataBlock& __restrict_
 
 //==============================================================================
 //
-inline RegisterArray<REGISTERS_PER_FRAME>
+inline RegisterArray<COLLECTION_REGISTERS_PER_FRAME>
 get_frame_collection_adcs(const dunedaq::detdataformats::wib::WIBFrame* __restrict__ frame)
 {
   // Each coldata block has 24 collection channels, so we have to
@@ -500,7 +500,7 @@ get_frame_collection_adcs(const dunedaq::detdataformats::wib::WIBFrame* __restri
   // 6 and 7) into the spaces in registers 0-5, so we first shuffle
   // register 6 so it has the items we want in the right place to
   // blend, and then blend
-  RegisterArray<REGISTERS_PER_FRAME> adcs;
+  RegisterArray<COLLECTION_REGISTERS_PER_FRAME> adcs;
 
   // A register where every 64-bit word is the 0th 64-bit word from the original register
   __m256i reg0_quad0 = _mm256_permute4x64_epi64(adcs_tmp.ymm(6), 0x00);
@@ -554,7 +554,7 @@ expand_message_adcs(const SUPERCHUNK_CHAR_STRUCT& __restrict__ ucs)
     const dunedaq::detdataformats::wib::WIBFrame* frame =
       reinterpret_cast<const dunedaq::detdataformats::wib::WIBFrame*>(&ucs) + iframe; // NOLINT
     FrameRegisters frame_regs = get_frame_divided_adcs(frame);
-    for (size_t iblock = 0; iblock < REGISTERS_PER_FRAME; ++iblock) {
+    for (size_t iblock = 0; iblock < COLLECTION_REGISTERS_PER_FRAME; ++iblock) {
       // Arrange it so that adjacent times are adjacent in
       // memory, which will hopefully make the trigger primitive
       // finding code itself a little easier
@@ -567,7 +567,7 @@ expand_message_adcs(const SUPERCHUNK_CHAR_STRUCT& __restrict__ ucs)
       adcs.collection_registers.set_ymm(iframe + iblock * FRAMES_PER_MSG, frame_regs.collection_registers.ymm(iblock));
     }
     // Same for induction registers
-    for (size_t iblock = 0; iblock < 10; ++iblock) {
+    for (size_t iblock = 0; iblock < INDUCTION_REGISTERS_PER_FRAME; ++iblock) {
       adcs.induction_registers.set_ymm(iframe + iblock * FRAMES_PER_MSG, frame_regs.induction_registers.ymm(iblock));
     }
   }
@@ -584,7 +584,7 @@ expand_message_adcs_inplace(const dunedaq::fdreadoutlibs::types::WIB_SUPERCHUNK_
     const dunedaq::detdataformats::wib::WIBFrame* frame =
       reinterpret_cast<const dunedaq::detdataformats::wib::WIBFrame*>(ucs) + iframe; // NOLINT
     FrameRegisters frame_regs = get_frame_divided_adcs(frame);
-    for (size_t iblock = 0; iblock < REGISTERS_PER_FRAME; ++iblock) {
+    for (size_t iblock = 0; iblock < COLLECTION_REGISTERS_PER_FRAME; ++iblock) {
       // Arrange it so that adjacent times are adjacent in
       // memory, which will hopefully make the trigger primitive
       // finding code itself a little easier
@@ -597,7 +597,7 @@ expand_message_adcs_inplace(const dunedaq::fdreadoutlibs::types::WIB_SUPERCHUNK_
       collection_registers->set_ymm(iframe + iblock * FRAMES_PER_MSG, frame_regs.collection_registers.ymm(iblock));
     }
     // Same for induction registers
-    for (size_t iblock = 0; iblock < 10; ++iblock) {
+    for (size_t iblock = 0; iblock < INDUCTION_REGISTERS_PER_FRAME; ++iblock) {
       induction_registers->set_ymm(iframe + iblock * FRAMES_PER_MSG, frame_regs.induction_registers.ymm(iblock));
     }
   }

--- a/include/fdreadoutlibs/wib/tpg/TPGConstants.hpp
+++ b/include/fdreadoutlibs/wib/tpg/TPGConstants.hpp
@@ -30,7 +30,8 @@ const constexpr std::size_t FRAMES_PER_MSG = 12;
 
 // How many collection-wire AVX2 registers are returned per
 // frame.
-const constexpr std::size_t REGISTERS_PER_FRAME = 6;
+const constexpr std::size_t COLLECTION_REGISTERS_PER_FRAME = 6;
+const constexpr std::size_t INDUCTION_REGISTERS_PER_FRAME = 10;
 
 // How many bytes are in an AVX2 register
 const constexpr std::size_t BYTES_PER_REGISTER = 32;
@@ -41,7 +42,8 @@ const constexpr std::size_t SAMPLES_PER_REGISTER = 16;
 // One netio message's worth of collection channel ADCs after
 // expansion: 12 frames per message times 8 registers per frame times
 // 32 bytes (256 bits) per register
-const constexpr std::size_t COLLECTION_ADCS_SIZE = BYTES_PER_REGISTER * REGISTERS_PER_FRAME * FRAMES_PER_MSG;
+const constexpr std::size_t COLLECTION_ADCS_SIZE = BYTES_PER_REGISTER * COLLECTION_REGISTERS_PER_FRAME * FRAMES_PER_MSG;
+const constexpr std::size_t INDUCTION_ADCS_SIZE  = BYTES_PER_REGISTER * INDUCTION_REGISTERS_PER_FRAME  * FRAMES_PER_MSG;
 
 } // namespace swtpg
 


### PR DESCRIPTION
This PR adds functionality to `WIBFrameProcessor` to run the hit-finding on all channels. Previous tests have suggested that a single thread can't keep up with the hit-finding on all channels, so this implementation does frame expansion and collection-channel hit-finding on one thread, with induction-channel hit-finding on another thread. 

The collection-channel thread (call it `C`) expands each superchunk, then signals via an atomic bool to the induction thread (call it `I`) that an expanded set of induction channels is ready. `C` runs hit-finding on collection channels while `I` runs hit-finding on its own channels. `C` then waits for `I` to signal (via the same atomic) that it's done, and adds both sets of hits to the TP handler. The reason for doing it this way, rather than sending the induction items to `I` via a queue, is to ensure that the pushes to the TP handler stay in sync. With a bit more thinking about how the TP handler works, we could probably change this, but it's done this way for now.

Something that surprised me at first is that having `C` and `I` talk to each other via a `condition_variable` doesn't keep up with the data rate. Similarly, putting any `sleep` in the loop that spins on the atomic bool while waiting for the other thread causes backlog. I think the reason is that we have 6 microseconds (12 ticks of 2 MHz) to process each superchunk, and scheduling out the thread causes a delay of more than that. So the induction thread spins a whole CPU, which is kind of unfortunate. An implementation using a queue would give some buffering and might help with this.

In the course of testing this code, I found a bug in the channel mapping, from AVX register indices to offline channel number, which this PR also fixes.

The implementation keeps up with the data rate on `epdtdifogkv01`, when I run a single link, and produces hits that look sensible (see post in #data-selection on slack). Need to test with 7 links on whichever machine is actually reading out the VD coldbox.

(Currently draft because I don't know which branches are open for changes, and this needs to go in 2.10.1)