### PR TITLE
Pass TPSet send topic through WIBFrameProcessor to WIBTPHandler

### DIFF
--- a/include/fdreadoutlibs/wib/WIBFrameProcessor.hpp
+++ b/include/fdreadoutlibs/wib/WIBFrameProcessor.hpp
@@ -247,7 +247,7 @@ public:
       m_channel_map = dunedaq::detchannelmaps::make_map(config.channel_map_name);
 
       m_tphandler.reset(
-        new WIBTPHandler(*m_tp_sink, *m_tpset_sink, config.tp_timeout, config.tpset_window_size, m_geoid));
+        new WIBTPHandler(*m_tp_sink, *m_tpset_sink, config.tp_timeout, config.tpset_window_size, m_geoid, config.tpset_topic));
 
       // m_induction_items_to_process = std::make_unique<readoutlibs::IterableQueueModel<InductionItemToProcess>>(
       //   200000, false, 0, true, 64); // 64 byte aligned

--- a/include/fdreadoutlibs/wib/WIBTPHandler.hpp
+++ b/include/fdreadoutlibs/wib/WIBTPHandler.hpp
@@ -28,12 +28,14 @@ public:
                         iomanager::SenderConcept<trigger::TPSet>& tpset_sink,
                         uint64_t tp_timeout,        // NOLINT(build/unsigned)
                         uint64_t tpset_window_size, // NOLINT(build/unsigned)
-                        daqdataformats::GeoID geoId)
+                        daqdataformats::GeoID geoId,
+                        std::string tpset_topic)
     : m_tp_sink(tp_sink)
     , m_tpset_sink(tpset_sink)
     , m_tp_timeout(tp_timeout)
     , m_tpset_window_size(tpset_window_size)
     , m_geoid(geoId)
+    , m_tpset_topic(tpset_topic)
   {}
 
   void set_run_number(daqdataformats::run_number_t run_number)
@@ -83,7 +85,7 @@ public:
       }
 
       try {
-        m_tpset_sink.send(std::move(tpset), std::chrono::milliseconds(10));
+        m_tpset_sink.send(std::move(tpset), std::chrono::milliseconds(10), m_tpset_topic);
         m_sent_tpsets++;
       } catch (const dunedaq::iomanager::TimeoutExpired& excpt) {
         ers::error(readoutlibs::CannotWriteToQueue(ERS_HERE, m_geoid, "m_tpset_sink"));
@@ -113,7 +115,8 @@ private:
   uint64_t m_tpset_window_size;    // NOLINT(build/unsigned)
   uint64_t m_next_tpset_seqno = 0; // NOLINT(build/unsigned)
   daqdataformats::GeoID m_geoid;
-
+  std::string m_tpset_topic;
+  
   std::atomic<size_t> m_sent_tps{ 0 };    // NOLINT(build/unsigned)
   std::atomic<size_t> m_sent_tpsets{ 0 }; // NOLINT(build/unsigned)
 


### PR DESCRIPTION
This is needed so that TPSets can be received by the trigger and TPSet writer, with the new communications API. Corresponding daqconf modifications are on the `philiprodrigues/readoutlibs-buffer` branch of `daqconf`