### PR TITLE
Ethernet readout support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,9 @@ daq_add_library(
 )
 
 ##############################################################################
+# Apps
 
+daq_add_application(TDEFileCreator TDEFileCreator.cxx TEST LINK_LIBRARIES fdreadoutlibs)
 
 ##############################################################################
 # Installation

--- a/include/fdreadoutlibs/FDReadoutTypes.hpp
+++ b/include/fdreadoutlibs/FDReadoutTypes.hpp
@@ -193,7 +193,7 @@ struct TDE_AMC_CHUNK
   // static const constexpr size_t fixed_payload_size = 5568;
   static const constexpr daqdataformats::GeoID::SystemType system_type = daqdataformats::GeoID::SystemType::kTPC;
   static const constexpr daqdataformats::FragmentType fragment_type = daqdataformats::FragmentType::kTPCData;
-  static const constexpr uint64_t expected_tick_difference = 25; // 2 MHz@50MHz clock // NOLINT(build/unsigned)
+  static const constexpr uint64_t expected_tick_difference = 1000; // NOLINT(build/unsigned)
 
 };
 

--- a/include/fdreadoutlibs/FDReadoutTypes.hpp
+++ b/include/fdreadoutlibs/FDReadoutTypes.hpp
@@ -131,14 +131,14 @@ struct WIB_SUPERCHUNK_STRUCT
   static const constexpr uint64_t expected_tick_difference = 25; // 2 MHz@50MHz clock // NOLINT(build/unsigned)
 };
 
-const constexpr std::size_t TDE_AMC_CHUNK_SIZE = 64 * sizeof(dunedaq::detdataformats::tde::TDE16Frame);
-struct TDE_AMC_CHUNK
+const constexpr std::size_t TDE_AMC_STRUCT_SIZE = 64 * sizeof(dunedaq::detdataformats::tde::TDE16Frame);
+struct TDE_AMC_STRUCT
 {
   using FrameType = dunedaq::detdataformats::tde::TDE16Frame;
 
-  char data[TDE_AMC_CHUNK_SIZE];
+  char data[TDE_AMC_STRUCT_SIZE];
 
-  bool operator<(const TDE_AMC_CHUNK& other) const
+  bool operator<(const TDE_AMC_STRUCT& other) const
   {
     auto thisptr = reinterpret_cast<const FrameType*>(&data);        // NOLINT
     auto otherptr = reinterpret_cast<const FrameType*>(&other.data); // NOLINT
@@ -187,7 +187,7 @@ struct TDE_AMC_CHUNK
 
   FrameType* end()
   {
-    return reinterpret_cast<FrameType*>(data + TDE_AMC_CHUNK_SIZE); // NOLINT
+    return reinterpret_cast<FrameType*>(data + TDE_AMC_STRUCT_SIZE); // NOLINT
   }
 
   // static const constexpr size_t fixed_payload_size = 5568;

--- a/include/fdreadoutlibs/FDReadoutTypes.hpp
+++ b/include/fdreadoutlibs/FDReadoutTypes.hpp
@@ -17,6 +17,7 @@
 #include "detdataformats/ssp/SSPTypes.hpp"
 #include "detdataformats/wib/WIBFrame.hpp"
 #include "detdataformats/wib2/WIB2Frame.hpp"
+#include "detdataformats/tde/TDE16Frame.hpp"
 #include "detdataformats/wib/RawWIBTp.hpp"
 #include "triggeralgs/TriggerPrimitive.hpp"
 
@@ -128,6 +129,72 @@ struct WIB_SUPERCHUNK_STRUCT
   static const constexpr daqdataformats::GeoID::SystemType system_type = daqdataformats::GeoID::SystemType::kTPC;
   static const constexpr daqdataformats::FragmentType fragment_type = daqdataformats::FragmentType::kTPCData;
   static const constexpr uint64_t expected_tick_difference = 25; // 2 MHz@50MHz clock // NOLINT(build/unsigned)
+};
+
+const constexpr std::size_t TDE_AMC_CHUNK_SIZE = 64 * sizeof(dunedaq::detdataformats::tde::TDE16Frame);
+struct TDE_AMC_CHUNK
+{
+  using FrameType = dunedaq::detdataformats::tde::TDE16Frame;
+
+  char data[TDE_AMC_CHUNK_SIZE];
+
+  bool operator<(const TDE_AMC_CHUNK& other) const
+  {
+    auto thisptr = reinterpret_cast<const FrameType*>(&data);        // NOLINT
+    auto otherptr = reinterpret_cast<const FrameType*>(&other.data); // NOLINT
+    return thisptr->get_timestamp() < otherptr->get_timestamp() ? true : false;
+  }
+
+  uint64_t get_first_timestamp() const // NOLINT(build/unsigned)
+  {
+    return reinterpret_cast<const FrameType*>(&data)->get_timestamp(); // NOLINT
+  }
+
+  void set_first_timestamp(uint64_t ts) // NOLINT(build/unsigned)
+  {
+    reinterpret_cast<FrameType*>(&data)->get_tde_header()->set_timestamp(ts); // NOLINT
+  }
+
+  void fake_timestamps(uint64_t first_timestamp, uint64_t) // NOLINT(build/unsigned)
+  {
+    auto tdef = reinterpret_cast<FrameType*>(((uint8_t*)(&data))); // NOLINT
+    for (int i = 0; i < 64; ++i) {
+      auto wfh = const_cast<dunedaq::detdataformats::tde::TDE16Header*>(tdef->get_tde_header());
+      wfh->set_timestamp(first_timestamp);
+      tdef++;
+    }
+  }
+
+  void fake_frame_errors(std::vector<uint16_t>* fake_errors) // NOLINT(build/unsigned)
+  {
+    auto tdef = reinterpret_cast<FrameType*>(((uint8_t*)(&data))); // NOLINT
+    for (int i = 0; i < 64; ++i) {
+      tdef->set_tde_errors((*fake_errors)[i]);
+      tdef++;
+    }
+  }
+
+  size_t get_payload_size() { return 64 * sizeof(FrameType); }
+
+  size_t get_num_frames() { return 64; }
+
+  size_t get_frame_size() { return sizeof(FrameType); }
+
+  FrameType* begin()
+  {
+    return reinterpret_cast<FrameType*>(&data[0]); // NOLINT
+  }
+
+  FrameType* end()
+  {
+    return reinterpret_cast<FrameType*>(data + TDE_AMC_CHUNK_SIZE); // NOLINT
+  }
+
+  // static const constexpr size_t fixed_payload_size = 5568;
+  static const constexpr daqdataformats::GeoID::SystemType system_type = daqdataformats::GeoID::SystemType::kTPC;
+  static const constexpr daqdataformats::FragmentType fragment_type = daqdataformats::FragmentType::kTPCData;
+  static const constexpr uint64_t expected_tick_difference = 25; // 2 MHz@50MHz clock // NOLINT(build/unsigned)
+
 };
 
 static_assert(sizeof(struct dunedaq::detdataformats::wib::WIBFrame)*12 == WIB_SUPERCHUNK_SIZE,

--- a/include/fdreadoutlibs/tde/TDECrateSourceEmulatorModel.hpp
+++ b/include/fdreadoutlibs/tde/TDECrateSourceEmulatorModel.hpp
@@ -1,0 +1,285 @@
+/**
+ * @file TDECrateSourceEmulatorModel.hpp Emulates a source with given raw type
+ *
+ * This is part of the DUNE DAQ , copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+#ifndef READOUTLIBS_INCLUDE_READOUTLIBS_MODELS_TDECRATESOURCEEMULATORMODEL_HPP_
+#define READOUTLIBS_INCLUDE_READOUTLIBS_MODELS_TDECRATESOURCEEMULATORMODEL_HPP_
+
+#include "iomanager/IOManager.hpp"
+#include "iomanager/Sender.hpp"
+
+#include "logging/Logging.hpp"
+
+#include "opmonlib/InfoCollector.hpp"
+
+#include "readoutlibs/sourceemulatorconfig/Nljs.hpp"
+#include "readoutlibs/sourceemulatorinfo/InfoNljs.hpp"
+
+#include "readoutlibs/ReadoutIssues.hpp"
+#include "readoutlibs/concepts/SourceEmulatorConcept.hpp"
+#include "readoutlibs/utils/ErrorBitGenerator.hpp"
+#include "readoutlibs/utils/FileSourceBuffer.hpp"
+#include "readoutlibs/utils/RateLimiter.hpp"
+#include "readoutlibs/utils/ReusableThread.hpp"
+
+#include "detdataformats/tde/TDE16Frame.hpp"
+
+#include "unistd.h"
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <random>
+#include <string>
+#include <utility>
+#include <vector>
+
+using dunedaq::readoutlibs::logging::TLVL_TAKE_NOTE;
+using dunedaq::readoutlibs::logging::TLVL_WORK_STEPS;
+
+namespace dunedaq {
+namespace readoutlibs {
+
+template<class ReadoutType>
+class TDECrateSourceEmulatorModel : public SourceEmulatorConcept
+{
+public:
+  explicit TDECrateSourceEmulatorModel(std::string name,
+                               std::atomic<bool>& run_marker,
+                               uint64_t time_tick_diff, // NOLINT(build/unsigned)
+                               double dropout_rate,
+                               double frame_error_rate,
+                               double rate_khz)
+    : m_run_marker(run_marker)
+    , m_time_tick_diff(time_tick_diff)
+    , m_dropout_rate(dropout_rate)
+    , m_frame_error_rate(frame_error_rate)
+    , m_packet_count{ 0 }
+    , m_raw_sender_timeout_ms(0)
+    , m_raw_data_sender(nullptr)
+    , m_producer_thread(0)
+    , m_name(name)
+    , m_rate_khz(rate_khz)
+  {}
+
+  void init(const nlohmann::json& /*args*/) {}
+
+  void set_sender(const std::string& conn_name)
+  {
+    if (!m_sender_is_set) {
+      m_raw_data_sender = get_iom_sender<ReadoutType>(conn_name);
+      m_sender_is_set = true;
+    } else {
+      // ers::error();
+    }
+  }
+
+  void conf(const nlohmann::json& args, const nlohmann::json& link_conf)
+  {
+    if (m_is_configured) {
+      TLOG_DEBUG(TLVL_WORK_STEPS) << "This emulator is already configured!";
+    } else {
+      m_conf = args.get<module_conf_t>();
+      m_link_conf = link_conf.get<link_conf_t>();
+      m_raw_sender_timeout_ms = std::chrono::milliseconds(m_conf.queue_timeout_ms);
+
+      std::mt19937 mt(rand()); // NOLINT(runtime/threadsafe_fn)
+      std::uniform_real_distribution<double> dis(0.0, 1.0);
+
+      m_geoid.element_id = m_link_conf.geoid.element;
+      m_geoid.region_id = m_link_conf.geoid.region;
+      m_geoid.system_type = ReadoutType::system_type;
+
+      m_file_source = std::make_unique<FileSourceBuffer>(m_link_conf.input_limit, sizeof(ReadoutType) * 12);
+      try {
+        m_file_source->read(m_link_conf.data_filename);
+      } catch (const ers::Issue& ex) {
+        ers::fatal(ex);
+        throw ConfigurationError(ERS_HERE, m_geoid, "", ex);
+      }
+      m_dropouts_length = m_link_conf.random_population_size;
+      if (m_dropout_rate == 0.0) {
+        m_dropouts = std::vector<bool>(1);
+      } else {
+        m_dropouts = std::vector<bool>(m_dropouts_length);
+      }
+      for (size_t i = 0; i < m_dropouts.size(); ++i) {
+        m_dropouts[i] = dis(mt) >= m_dropout_rate;
+      }
+
+      m_frame_errors_length = m_link_conf.random_population_size;
+      m_frame_error_rate = m_link_conf.emu_frame_error_rate;
+      m_error_bit_generator = ErrorBitGenerator(m_frame_error_rate);
+      m_error_bit_generator.generate();
+
+      m_is_configured = true;
+    }
+    // Configure thread:
+    m_producer_thread.set_name("fakeprod", m_link_conf.geoid.element);
+  }
+
+  void scrap(const nlohmann::json& /*args*/)
+  {
+    m_file_source.reset();
+    m_is_configured = false;
+  }
+
+  bool is_configured() override { return m_is_configured; }
+
+  void start(const nlohmann::json& /*args*/)
+  {
+    m_packet_count_tot = 0;
+    TLOG_DEBUG(TLVL_WORK_STEPS) << "Starting threads...";
+    m_rate_limiter = std::make_unique<RateLimiter>(m_rate_khz / m_link_conf.slowdown);
+    // m_stats_thread.set_work(&TDECrateSourceEmulatorModel<ReadoutType>::run_stats, this);
+    m_producer_thread.set_work(&TDECrateSourceEmulatorModel<ReadoutType>::run_produce, this);
+  }
+
+  void stop(const nlohmann::json& /*args*/)
+  {
+    while (!m_producer_thread.get_readiness()) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+  }
+
+  void get_info(opmonlib::InfoCollector& ci, int /*level*/)
+  {
+    sourceemulatorinfo::Info info;
+    info.packets = m_packet_count_tot.load();
+    info.new_packets = m_packet_count.exchange(0);
+
+    ci.add(info);
+  }
+
+protected:
+  void run_produce()
+  {
+    TLOG_DEBUG(TLVL_WORK_STEPS) << "Data generation thread " << m_this_link_number << " started";
+
+    // pthread_setname_np(pthread_self(), get_name().c_str());
+
+    uint offset = 0; // NOLINT(build/unsigned)
+    auto& source = m_file_source->get();
+
+    int num_elem = m_file_source->num_elements();
+    if (num_elem == 0) {
+      TLOG_DEBUG(TLVL_WORK_STEPS) << "No elements to read from buffer! Sleeping...";
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      num_elem = m_file_source->num_elements();
+    }
+
+    auto rptr = reinterpret_cast<ReadoutType*>(source.data()); // NOLINT
+
+    // set the initial timestamp to a configured value, otherwise just use the timestamp from the header
+    uint64_t ts_0 = (m_conf.set_t0_to >= 0) ? m_conf.set_t0_to : rptr->get_first_timestamp(); // NOLINT(build/unsigned)
+    TLOG_DEBUG(TLVL_BOOKKEEPING) << "First timestamp in the source file: " << ts_0;
+    uint64_t timestamp = ts_0; // NOLINT(build/unsigned)
+    int dropout_index = 0;
+
+    while (m_run_marker.load()) {
+      // Which element to push to the buffer
+      if (offset == num_elem * sizeof(ReadoutType) * 12 || (offset + 1) * sizeof(ReadoutType) * 12 > source.size()) {
+        offset = 0;
+      }
+
+      bool create_frame = m_dropouts[dropout_index]; // NOLINT(runtime/threadsafe_fn)
+      dropout_index = (dropout_index + 1) % m_dropouts.size();
+      if (create_frame) {
+        detdataformats::tde::TDE16Frame frames[12 * 64] ;
+        ::memcpy(static_cast<void*>(frames),
+                 static_cast<void*>(source.data() + offset * sizeof(ReadoutType) * 12),
+                 sizeof(ReadoutType) * 12);
+
+        std::vector<std::vector<detdataformats::tde::TDE16Frame>> v(12, std::vector<detdataformats::tde::TDE16Frame>(64));
+        for (int i = 0; i < 12 * 64; i++) {
+          v[frames[i].get_tde_header()->slot][frames[i].get_tde_header()->link] = frames[i];
+        }
+        for (int i = 0; i < 12; i++)
+        {
+          ReadoutType* payload = reinterpret_cast<ReadoutType*>(v[i].data());
+
+          // Fake timestamp
+          payload->fake_timestamps(timestamp, m_time_tick_diff);
+
+          // Introducing frame errors
+          std::vector<uint16_t> frame_errs; // NOLINT(build/unsigned)
+          for (size_t i = 0; i < rptr->get_num_frames(); ++i) {
+          frame_errs.push_back(m_error_bit_generator.next());
+          }
+          payload->fake_frame_errors(&frame_errs);
+
+          // send it
+          try {
+          m_raw_data_sender->send(std::move(*payload), m_raw_sender_timeout_ms);
+          } catch (ers::Issue& excpt) {
+          ers::warning(CannotWriteToQueue(ERS_HERE, m_geoid, "raw data input queue", excpt));
+          // std::runtime_error("Queue timed out...");
+          }
+        }
+
+        // Count packet and limit rate if needed.
+        ++offset;
+        ++m_packet_count;
+        ++m_packet_count_tot;
+      }
+
+      timestamp += m_time_tick_diff;
+
+      m_rate_limiter->limit();
+    }
+    TLOG_DEBUG(TLVL_WORK_STEPS) << "Data generation thread " << m_this_link_number << " finished";
+  }
+
+private:
+  // Constuctor params
+  std::atomic<bool>& m_run_marker;
+
+  // CONFIGURATION
+  uint32_t m_this_apa_number;  // NOLINT(build/unsigned)
+  uint32_t m_this_link_number; // NOLINT(build/unsigned)
+
+  uint64_t m_time_tick_diff; // NOLINT(build/unsigned)
+  double m_dropout_rate;
+  double m_frame_error_rate;
+
+  // STATS
+  std::atomic<int> m_packet_count{ 0 };
+  std::atomic<int> m_packet_count_tot{ 0 };
+
+  sourceemulatorconfig::Conf m_cfg;
+
+  // RAW SENDER
+  std::chrono::milliseconds m_raw_sender_timeout_ms;
+  using raw_sender_ct = iomanager::SenderConcept<ReadoutType>;
+  std::shared_ptr<raw_sender_ct> m_raw_data_sender;
+
+  bool m_sender_is_set = false;
+  using module_conf_t = dunedaq::readoutlibs::sourceemulatorconfig::Conf;
+  module_conf_t m_conf;
+  using link_conf_t = dunedaq::readoutlibs::sourceemulatorconfig::LinkConfiguration;
+  link_conf_t m_link_conf;
+
+  std::unique_ptr<RateLimiter> m_rate_limiter;
+  std::unique_ptr<FileSourceBuffer> m_file_source;
+  ErrorBitGenerator m_error_bit_generator;
+
+  ReusableThread m_producer_thread;
+
+  std::string m_name;
+  bool m_is_configured = false;
+  double m_rate_khz;
+
+  std::vector<bool> m_dropouts; // Random population
+  std::vector<bool> m_frame_errors;
+
+  uint m_dropouts_length = 10000; // NOLINT(build/unsigned) Random population size
+  uint m_frame_errors_length = 10000;
+  daqdataformats::GeoID m_geoid;
+};
+
+} // namespace readoutlibs
+} // namespace dunedaq
+
+#endif // READOUTLIBS_INCLUDE_READOUTLIBS_MODELS_TDECRATESOURCEEMULATORMODEL_HPP_

--- a/include/fdreadoutlibs/tde/TDEFrameGrouper.hpp
+++ b/include/fdreadoutlibs/tde/TDEFrameGrouper.hpp
@@ -1,0 +1,39 @@
+/*
+ * @file TDEFrameGrouper.hpp Group TDE frames in together based on their slot number
+ *
+ * This is part of the DUNE DAQ , copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+#ifndef FDREADOUTLIBS_INCLUDE_FDREADOUTLIBS_TDE_TDEFRAMEGROUPER_HPP_
+#define FDREADOUTLIBS_INCLUDE_FDREADOUTLIBS_TDE_TDEFRAMEGROUPER_HPP_
+
+#include "detdataformats/tde/TDE16Frame.hpp"
+#include "fdreadoutlibs/FDReadoutTypes.hpp"
+
+using dunedaq::readoutlibs::logging::TLVL_BOOKKEEPING;
+
+namespace dunedaq {
+namespace fdreadoutlibs {
+
+class TDEFrameGrouper
+{
+
+public:
+
+  void group(std::vector<std::vector<detdataformats::tde::TDE16Frame>>& v)
+  {
+    for (int i = 0; i < 12 * 64; i++) {
+        v[frames[i].get_tde_header()->slot][frames[i].get_tde_header()->link] = frames[i];
+    }
+  }
+
+private:
+};
+
+} // namespace fdreadoutlibs
+} // namespace dunedaq
+
+#endif // FDREADOUTLIBS_INCLUDE_FDREADOUTLIBS_TDE_TDEFRAMEGROUPER_HPP_
+
+

--- a/include/fdreadoutlibs/tde/TDEFrameGrouper.hpp
+++ b/include/fdreadoutlibs/tde/TDEFrameGrouper.hpp
@@ -9,7 +9,8 @@
 #define FDREADOUTLIBS_INCLUDE_FDREADOUTLIBS_TDE_TDEFRAMEGROUPER_HPP_
 
 #include "detdataformats/tde/TDE16Frame.hpp"
-#include "fdreadoutlibs/FDReadoutTypes.hpp"
+
+#include <vector>
 
 using dunedaq::readoutlibs::logging::TLVL_BOOKKEEPING;
 
@@ -21,7 +22,7 @@ class TDEFrameGrouper
 
 public:
 
-  void group(std::vector<std::vector<detdataformats::tde::TDE16Frame>>& v)
+  void group(std::vector<std::vector<detdataformats::tde::TDE16Frame>>& v, detdataformats::tde::TDE16Frame* frames)
   {
     for (int i = 0; i < 12 * 64; i++) {
         v[frames[i].get_tde_header()->slot][frames[i].get_tde_header()->link] = frames[i];

--- a/include/fdreadoutlibs/tde/TDEFrameProcessor.hpp
+++ b/include/fdreadoutlibs/tde/TDEFrameProcessor.hpp
@@ -1,4 +1,4 @@
-
+/*
  * @file TDEFrameProcessor.hpp TDE specific Task based raw processor
  *
  * This is part of the DUNE DAQ , copyright 2020.

--- a/include/fdreadoutlibs/tde/TDEFrameProcessor.hpp
+++ b/include/fdreadoutlibs/tde/TDEFrameProcessor.hpp
@@ -1,0 +1,116 @@
+
+ * @file TDEFrameProcessor.hpp TDE specific Task based raw processor
+ *
+ * This is part of the DUNE DAQ , copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+#ifndef FDREADOUTLIBS_INCLUDE_FDREADOUTLIBS_TDE_TDEFRAMEPROCESSOR_HPP_
+#define FDREADOUTLIBS_INCLUDE_FDREADOUTLIBS_TDE_TDEFRAMEPROCESSOR_HPP_
+
+#include "readoutlibs/ReadoutIssues.hpp"
+#include "readoutlibs/models/TaskRawDataProcessorModel.hpp"
+
+#include "detdataformats/tde/TDE16Frame.hpp"
+#include "fdreadoutlibs/FDReadoutTypes.hpp"
+#include "logging/Logging.hpp"
+#include "readoutlibs/FrameErrorRegistry.hpp"
+#include "readoutlibs/ReadoutLogging.hpp"
+
+#include <atomic>
+#include <functional>
+#include <memory>
+#include <string>
+
+using dunedaq::readoutlibs::logging::TLVL_BOOKKEEPING;
+
+namespace dunedaq {
+namespace fdreadoutlibs {
+
+class TDEFrameProcessor : public readoutlibs::TaskRawDataProcessorModel<types::TDE_AMC_STRUCT>
+{
+
+public:
+  using inherited = readoutlibs::TaskRawDataProcessorModel<types::TDE_AMC_STRUCT>;
+  using frameptr = types::TDE_AMC_STRUCT*;
+  using tdeframeptr = dunedaq::detdataformats::tde::TDE16Frame*;
+  using timestamp_t = std::uint64_t; // NOLINT(build/unsigned)
+
+  explicit TDEFrameProcessor(std::unique_ptr<readoutlibs::FrameErrorRegistry>& error_registry)
+    : TaskRawDataProcessorModel<types::TDE_AMC_STRUCT>(error_registry)
+  {}
+
+  void conf(const nlohmann::json& args) override
+  {
+    TaskRawDataProcessorModel<types::TDE_AMC_STRUCT>::add_preprocess_task(
+      std::bind(&TDEFrameProcessor::timestamp_check, this, std::placeholders::_1));
+    // m_tasklist.push_back( std::bind(&TDEFrameProcessor::frame_error_check, this, std::placeholders::_1) );
+    TaskRawDataProcessorModel<types::TDE_AMC_STRUCT>::conf(args);
+  }
+
+protected:
+  // Internals
+  timestamp_t m_previous_ts = 0;
+  timestamp_t m_current_ts = 0;
+  bool m_first_ts_missmatch = true;
+  bool m_problem_reported = false;
+  std::atomic<int> m_ts_error_ctr{ 0 };
+
+  /**
+   * Pipeline Stage 1.: Check proper timestamp increments in TDE frames
+   * */
+  void timestamp_check(frameptr fp)
+  {
+    // If EMU data, emulate perfectly incrementing timestamp
+    if (inherited::m_emulator_mode) {         // emulate perfectly incrementing timestamp
+      uint64_t ts_next = m_previous_ts + 1000; // NOLINT(build/unsigned)
+      for (unsigned int i = 0; i < 64; ++i) { // NOLINT(build/unsigned)
+        auto tdef = reinterpret_cast<dunedaq::detdataformats::tde::TDE16Frame*>(((uint8_t*)fp) + i * sizeof(dunedaq::detdataformats::tde::TDE16Frame)); // NOLINT
+        auto tdefh = tdef->get_tde_header(); // const_cast<dunedaq::detdataformats::tde::TDE16Frame::Header*>(tdef->get_wib_header());
+        tdefh->set_timestamp(ts_next);
+      }
+    }
+
+    // Acquire timestamp
+    auto tdefptr = reinterpret_cast<dunedaq::detdataformats::tde::TDE16Frame*>(fp); // NOLINT
+    m_current_ts = tdefptr->get_timestamp();
+
+    // Check timestamp
+    if (m_current_ts - m_previous_ts != 1000) {
+      ++m_ts_error_ctr;
+      m_error_registry->add_error("MISSING_FRAMES",
+                                  readoutlibs::FrameErrorRegistry::ErrorInterval(m_previous_ts + 1000, m_current_ts));
+      if (m_first_ts_missmatch) { // log once
+        TLOG_DEBUG(TLVL_BOOKKEEPING) << "First timestamp MISSMATCH! -> | previous: " << std::to_string(m_previous_ts)
+                                     << " current: " + std::to_string(m_current_ts);
+        m_first_ts_missmatch = false;
+      }
+    }
+
+    if (m_ts_error_ctr > 1000) {
+      if (!m_problem_reported) {
+        TLOG() << "*** Data Integrity ERROR *** Timestamp continuity is completely broken! "
+               << "Something is wrong with the FE source or with the configuration!";
+        m_problem_reported = true;
+      }
+    }
+
+    m_previous_ts = m_current_ts;
+    m_last_processed_daq_ts = m_current_ts;
+  }
+
+  /**
+   * Pipeline Stage 2.: Check TDE headers for error flags
+   * */
+  void frame_error_check(frameptr /*fp*/)
+  {
+    // check error fields
+  }
+
+private:
+};
+
+} // namespace fdreadoutlibs
+} // namespace dunedaq
+
+#endif // FDREADOUTLIBS_INCLUDE_FDREADOUTLIBS_TDE_TDEFRAMEPROCESSOR_HPP_

--- a/test/apps/TDEFileCreator.cxx
+++ b/test/apps/TDEFileCreator.cxx
@@ -18,34 +18,33 @@ using namespace dunedaq;
 
 int main()
 {
-  int total_frames = 10 * 64;
+  int num_batches = 5;
 
   std::ofstream out("frames.bin", std::ios::out | std::ios::binary);
 
   std::random_device rd;
   std::default_random_engine rng(rd());
 
-  for (int batch = 0; batch < total_frames / 64; batch++)
+  for (int batch = 0; batch < num_batches; batch++)
   {
+    std::vector<detdataformats::tde::TDE16Frame> v;
     uint64_t timestamp = batch;
-    std::vector<int> v;
-    for (int iframe = 0; iframe < 64; iframe++)
+    for (int amc = 0; amc < 12; amc++)
     {
-      v.push_back(iframe);
+      for (int i = 0; i < 64; i++)
+      {
+        detdataformats::tde::TDE16Frame fr;
+        // Timestamp
+        fr.set_timestamp(timestamp);
+        // Channel
+        fr.get_tde_header()->slot = amc;
+        fr.get_tde_header()->link = i;
+        fr.set_adc_samples(batch,0);
+      }
     }
     std::shuffle(v.begin(), v.end(), rng);
-
-    for (int i = 0; i < 64; i++)
-    {
-      int iframe = v[i];
-      detdataformats::tde::TDE16Frame fr;
-      // Timestamp
-      fr.set_timestamp(timestamp);
-      // Channel
-      fr.get_tde_header()->crate = iframe;
-      fr.get_tde_header()->link = iframe;
-      fr.set_adc_samples(batch,0);
-      out.write(reinterpret_cast<char*>(&fr), sizeof(detdataformats::tde::TDE16Frame));
+    for (auto& fr: v) {
+        out.write(reinterpret_cast<char*>(&fr), sizeof(detdataformats::tde::TDE16Frame));
     }
   }
   out.close();

--- a/test/apps/TDEFileCreator.cxx
+++ b/test/apps/TDEFileCreator.cxx
@@ -10,6 +10,9 @@
 
 #include <iostream>
 #include <fstream>
+#include <vector>
+#include <random>
+#include <algorithm>
 
 using namespace dunedaq;
 
@@ -19,16 +22,29 @@ int main()
 
   std::ofstream out("frames.bin", std::ios::out | std::ios::binary);
 
+  std::random_device rd;
+  std::default_random_engine rng(rd());
+
   for (int batch = 0; batch < total_frames / 64; batch++)
   {
     uint64_t timestamp = batch;
+    std::vector<int> v;
     for (int iframe = 0; iframe < 64; iframe++)
     {
+      v.push_back(iframe);
+    }
+    std::shuffle(v.begin(), v.end(), rng);
+
+    for (int i = 0; i < 64; i++)
+    {
+      int iframe = v[i];
       detdataformats::tde::TDE16Frame fr;
       // Timestamp
       fr.set_timestamp(timestamp);
       // Channel
       fr.get_tde_header()->crate = iframe;
+      fr.get_tde_header()->link = iframe;
+      fr.set_adc_samples(batch,0);
       out.write(reinterpret_cast<char*>(&fr), sizeof(detdataformats::tde::TDE16Frame));
     }
   }

--- a/test/apps/TDEFileCreator.cxx
+++ b/test/apps/TDEFileCreator.cxx
@@ -15,7 +15,7 @@ using namespace dunedaq;
 
 int main()
 {
-  int total_frames = 100 * 64;
+  int total_frames = 10 * 64;
 
   std::ofstream out("frames.bin", std::ios::out | std::ios::binary);
 

--- a/test/apps/TDEFileCreator.cxx
+++ b/test/apps/TDEFileCreator.cxx
@@ -1,0 +1,37 @@
+/**
+ * @file TDEFileCreator.cxx Create a binary file with TDE Frames for reading it from readout
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "detdataformats/tde/TDE16Frame.hpp"
+
+#include <iostream>
+#include <fstream>
+
+using namespace dunedaq;
+
+int main()
+{
+  int total_frames = 100 * 64;
+
+  std::ofstream out("frames.bin", std::ios::out | std::ios::binary);
+
+  for (int batch = 0; batch < total_frames / 64; batch++)
+  {
+    uint64_t timestamp = batch;
+    for (int iframe = 0; iframe < 64; iframe++)
+    {
+      detdataformats::tde::TDE16Frame fr;
+      // Timestamp
+      fr.set_timestamp(timestamp);
+      // Channel
+      fr.get_tde_header()->crate = iframe;
+      out.write(reinterpret_cast<char*>(&fr), sizeof(detdataformats::tde::TDE16Frame));
+    }
+  }
+  out.close();
+
+}


### PR DESCRIPTION
This PR adds
- A `TDE_AMC_STRUCT` type that contains 64 TDE frames (since each AMC board has 64 channels)
- A `TDEFrameProcessor` responsible for checking that the timestamps are what they should be and check for frame errors, similar to what was done with WIB and WIB2 frames
- A `TDECrateSourceEmulatorModel` responsible for collecting the frames read from a file and pushing them to the latency buffer
- A `TDEFrameGrouper` that orders sets of unordered frames in groups of 64
- A `TDEFileCreator` that will create a `frames.bin` file with TDE frames that are shuffled in a similar way to how they will be received by readout

Comments:
- In contrast with the SourceEmulatorModel that is used for WIBFrames this one is not templated since it's specific for TDE frames. Maybe we could template it and it would also work for the 12b format?

TODO:
- Add support for the 12b format
- Correct value for the timestamps once known