### PR TITLE
firmware TP publishing fixes from VD coldbox

### DIFF
--- a/include/fdreadoutlibs/wib/RAWWIBTriggerPrimitiveProcessor.hpp
+++ b/include/fdreadoutlibs/wib/RAWWIBTriggerPrimitiveProcessor.hpp
@@ -67,7 +67,6 @@ public:
     auto config = args["rawdataprocessorconf"].get<readoutlibs::readoutconfig::RawDataProcessorConf>();
     if (config.enable_firmware_tpg) {
       m_fw_tpg_enabled = true;
-
       m_tphandler.reset(
             new WIBTPHandler(*m_tp_sink, *m_tpset_sink, config.tp_timeout, config.tpset_window_size, m_geoid, config.tpset_topic));
     }
@@ -77,15 +76,7 @@ public:
 
   void init(const nlohmann::json& args) override
   {
-    try {
-      auto queue_index = appfwk::connection_index(args, {});
-      if (queue_index.find("tp") != queue_index.end()) {
-        m_tp_source = get_iom_receiver<types::RAW_WIB_TRIGGERPRIMITIVE_STRUCT>(queue_index["tp_out"]);
-      }
-    } catch (const ers::Issue& excpt) {
-      // error
-    }
-
+    m_fake_timestamp = 0;
     try {
       auto queue_index = appfwk::connection_index(args, {});
       if (queue_index.find("tp_out") != queue_index.end()) {
@@ -104,7 +95,6 @@ public:
     if (m_fw_tpg_enabled) {
       rcif::cmd::StartParams start_params = args.get<rcif::cmd::StartParams>();
       m_tphandler->set_run_number(start_params.run);
-
       m_tphandler->reset();
       m_tps_dropped = 0;
     }
@@ -140,8 +130,10 @@ public:
 
 void tp_stitch(rwtp_ptr rwtp)
 {
+  m_fake_timestamp += 6400; 
   m_tp_frames++;
   uint64_t ts_0 = rwtp->m_head.get_timestamp(); // NOLINT
+  //uint64_t ts_0 = m_fake_timestamp; // NOLINT
   int nhits = rwtp->m_head.get_nhits(); // NOLINT
   uint8_t m_channel_no = rwtp->m_head.m_wire_no; // NOLINT
   uint8_t m_fiber_no = rwtp->m_head.m_fiber_no; // NOLINT
@@ -149,13 +141,15 @@ void tp_stitch(rwtp_ptr rwtp)
   uint8_t m_slot_no = rwtp->m_head.m_slot_no; // NOLINT
   uint offline_channel = m_channel_map->get_offline_channel_from_crate_slot_fiber_chan(m_crate_no, m_slot_no, m_fiber_no, m_channel_no);
 
+  TLOG(TLVL_WORK_STEPS) << "IRHRI fwTPG enabled -- will loop over " << nhits << " hits" ;
+  TLOG(TLVL_WORK_STEPS) << "IRHRI fwTPG enabled -- offline channel " << offline_channel ;
   for (int i = 0; i < nhits; i++) {
 
     triggeralgs::TriggerPrimitive trigprim;
     trigprim.time_start = ts_0 + rwtp->m_blocks[i].m_start_time * m_time_tick;
     trigprim.time_peak = ts_0 + rwtp->m_blocks[i].m_peak_time * m_time_tick;
     trigprim.time_over_threshold = (rwtp->m_blocks[i].m_end_time - rwtp->m_blocks[i].m_start_time) * m_time_tick;
-    trigprim.channel = offline_channel; // m_channel_no;
+    trigprim.channel = offline_channel; //offline_channel; // m_channel_no;
     trigprim.adc_integral = rwtp->m_blocks[i].m_sum_adc;
     trigprim.adc_peak = rwtp->m_blocks[i].m_peak_adc;
     trigprim.detid =
@@ -164,37 +158,41 @@ void tp_stitch(rwtp_ptr rwtp)
     trigprim.algorithm = triggeralgs::TriggerPrimitive::Algorithm::kTPCDefault;
     trigprim.version = 1;
 
+    TLOG(TLVL_WORK_STEPS) << "IRHRI tp_stitch time_start " << trigprim.time_start; 
+    TLOG(TLVL_WORK_STEPS) << "IRHRI tp_stitch time_peak " << trigprim.time_peak; 
+    TLOG(TLVL_WORK_STEPS) << "IRHRI tp_stitch time_over_threshold " << trigprim.time_over_threshold; 
+    TLOG(TLVL_WORK_STEPS) << "IRHRI tp_stitch channel " << trigprim.channel; 
+
     // stitch current hit to previous hit
-    if (m_A[m_channel_no].size() == 1) {
+    if (m_A[m_channel_no][m_fiber_no].size() == 1) {
       if (static_cast<int>(rwtp->m_blocks[i].m_start_time) == 0
           && (
-          static_cast<int>(trigprim.time_start) - static_cast<int>(m_A[m_channel_no][0].time_start)
+          static_cast<int>(trigprim.time_start) - static_cast<int>(m_A[m_channel_no][m_fiber_no][0].time_start)
              <= static_cast<int>(m_stitch_constant)
-          || (static_cast<int>(trigprim.time_start) - static_cast<int>(m_T[m_channel_no][0])
+          || (static_cast<int>(trigprim.time_start) - static_cast<int>(m_T[m_channel_no][m_fiber_no][0])
              <= static_cast<int>(m_stitch_constant))
              )
           ) {
         // current hit is continuation of previous hit
-        m_T[m_channel_no].clear();
-        if (trigprim.adc_peak > m_A[m_channel_no][0].adc_peak) {
-          m_A[m_channel_no][0].time_peak = trigprim.time_peak;
-          m_A[m_channel_no][0].adc_peak = trigprim.adc_peak;
+        m_T[m_channel_no][m_fiber_no].clear();
+        if (trigprim.adc_peak > m_A[m_channel_no][m_fiber_no][0].adc_peak) {
+          m_A[m_channel_no][m_fiber_no][0].time_peak = trigprim.time_peak;
+          m_A[m_channel_no][m_fiber_no][0].adc_peak = trigprim.adc_peak;
         }
-        m_A[m_channel_no][0].time_over_threshold += trigprim.time_over_threshold;
-        m_A[m_channel_no][0].adc_integral += trigprim.adc_integral;
-        //stitched_time_start = trigprim.time_start;
-        m_T[m_channel_no].push_back(trigprim.time_start);
+        m_A[m_channel_no][m_fiber_no][0].time_over_threshold += trigprim.time_over_threshold;
+        m_A[m_channel_no][m_fiber_no][0].adc_integral += trigprim.adc_integral;
+        m_T[m_channel_no][m_fiber_no].push_back(trigprim.time_start);
 
       } else {
         // current hit is not continuation of previous hit
         // add previous hit to TriggerPrimitives
-        if (!m_tphandler->add_tp(std::move(m_A[m_channel_no][0]), ts_0)) {
+        if (!m_tphandler->add_tp(std::move(m_A[m_channel_no][m_fiber_no][0]), ts_0)) {
           m_tps_dropped++;
         }
         m_tps_stitched++;
-        m_tphandler->try_sending_tpsets(ts_0);
-        m_A[m_channel_no].clear();
-        m_T[m_channel_no].clear();
+        m_tphandler->try_sending_tpsets(ts_0); 
+        m_A[m_channel_no][m_fiber_no].clear();
+        m_T[m_channel_no][m_fiber_no].clear();
       }
     }
 
@@ -204,45 +202,42 @@ void tp_stitch(rwtp_ptr rwtp)
     uint8_t m_tp_end_time = rwtp->m_blocks[i].m_end_time; // NOLINT
  
     if (m_tp_continue == 0 && m_tp_end_time != 63) {
-      if (m_A[m_channel_no].size() == 1) {
+      if (m_A[m_channel_no][m_fiber_no].size() == 1) {
         // the current hit completes one stitched TriggerPrimitive
-        //tp_start_time = m_A[m_channel_no][0].time_start;
-        if (!m_tphandler->add_tp(std::move(m_A[m_channel_no][0]), ts_0)) {
+        if (!m_tphandler->add_tp(std::move(m_A[m_channel_no][m_fiber_no][0]), ts_0)) {
           m_tps_dropped++;
         }
-        m_tphandler->try_sending_tpsets(ts_0);
+        m_tphandler->try_sending_tpsets(ts_0); 
         m_tps_stitched++;
-        m_A[m_channel_no].clear();
-        m_T[m_channel_no].clear();
+        m_A[m_channel_no][m_fiber_no].clear();
+        m_T[m_channel_no][m_fiber_no].clear();
       } else {
         // the current hit is one TriggerTrimitive
-        //tp_start_time = trigprim.time_start;
         if (!m_tphandler->add_tp(std::move(trigprim), ts_0)) {
           m_tps_dropped++;
         }
-        m_tphandler->try_sending_tpsets(ts_0);
+        m_tphandler->try_sending_tpsets(ts_0);  
         m_tps_stitched++;      
       }
     } else {
       // the current hit starts one TriggerPrimitive
-      //tp_start_time = trigprim.time_start;
-      if (m_A[m_channel_no].size() == 0) {
-        m_A[m_channel_no].push_back(trigprim);
-        m_T[m_channel_no].push_back(trigprim.time_start);
+      if (m_A[m_channel_no][m_fiber_no].size() == 0) {
+        m_A[m_channel_no][m_fiber_no].push_back(trigprim);
+        m_T[m_channel_no][m_fiber_no].push_back(trigprim.time_start);
       } else { // decide to add long TriggerPrimitive even when it doesn't end properly
                // this is rare case and can be removed for efficiency    
         // the current hit is "bad"
         // add one TriggerPrimitive from previous stitched hits except the current hit  
         if ( m_tp_continue == 0 && m_tp_end_time == 63 &&
-             static_cast<int>(trigprim.time_start) - static_cast<int>(m_T[m_channel_no][0])
+             static_cast<int>(trigprim.time_start) - static_cast<int>(m_T[m_channel_no][m_fiber_no][0])
              <= static_cast<int>(m_stitch_constant)) {
-          if (!m_tphandler->add_tp(std::move(m_A[m_channel_no][0]), ts_0)) {
+          if (!m_tphandler->add_tp(std::move(m_A[m_channel_no][m_fiber_no][0]), ts_0)) {
             m_tps_dropped++;
           }
-          m_tphandler->try_sending_tpsets(ts_0);
+          m_tphandler->try_sending_tpsets(ts_0); 
           m_tps_stitched++;      
-          m_A[m_channel_no].clear();
-          m_T[m_channel_no].clear();
+          m_A[m_channel_no][m_fiber_no].clear();
+          m_T[m_channel_no][m_fiber_no].clear();
         }
       }
     }
@@ -265,6 +260,7 @@ void tp_unpack(frame_ptr fr)
     return;
   }
 
+  
   int offset = 0;
   while (offset <= num_elem) {
 
@@ -272,16 +268,20 @@ void tp_unpack(frame_ptr fr)
 
     // Count number of subframes in a TP frame
     int n = 1;
-    while (reinterpret_cast<types::TpSubframe*>(((uint8_t*)srcbuffer.data()) // NOLINT
-           + offset + (n-1)*RAW_WIB_TP_SUBFRAME_SIZE)->word3 != 0xDEADBEEF) {
-      n++;
+    bool ped_found { false };
+    for (n=1; offset+(n-1)*RAW_WIB_TP_SUBFRAME_SIZE<num_elem; ++n) {
+      if (reinterpret_cast<types::TpSubframe*>(((uint8_t*)srcbuffer.data()) // NOLINT
+           + offset + (n-1)*RAW_WIB_TP_SUBFRAME_SIZE)->word3 == 0xDEADBEEF) {
+        ped_found = true;
+        break; 
+      }  
     }
+    if (!ped_found) return;
 
     int bsize = n * RAW_WIB_TP_SUBFRAME_SIZE;
     std::vector<char> tmpbuffer;
     tmpbuffer.reserve(bsize);
     int nhits = n - 2;
-
     // add header block 
     ::memcpy(static_cast<void*>(tmpbuffer.data() + 0),
              static_cast<void*>(srcbuffer.data() + offset),
@@ -332,8 +332,8 @@ private:
   static const constexpr std::size_t RAW_WIB_TP_SUBFRAME_SIZE = 12;
 
   // stitching algorithm
-  std::vector<triggeralgs::TriggerPrimitive> m_A[256]; // keep track of TPs to stitch per channel
-  std::vector<uint64_t> m_T[256]; // NOLINT // keep track of last stitched start time
+  std::vector<triggeralgs::TriggerPrimitive> m_A[256][10]; // keep track of TPs to stitch per channel
+  std::vector<uint64_t> m_T[256][10]; // NOLINT // keep track of last stitched start time
   std::atomic<uint64_t> m_tps_stitched { 0 }; // NOLINT
   std::atomic<uint64_t> m_tp_frames  { 0 }; // NOLINT
   uint64_t m_stitch_constant = 1600; // NOLINT  // one packet = 64 * 25 ns
@@ -345,6 +345,7 @@ private:
   std::unique_ptr<WIBTPHandler> m_tphandler;
   std::atomic<uint64_t> m_tps_dropped{ 0 }; // NOLINT
   std::shared_ptr<detchannelmaps::TPCChannelMap> m_channel_map;
+  uint64_t m_fake_timestamp{ 0 };
 
   // info
   std::atomic<uint64_t> m_sent_tps{ 0 }; // NOLINT(build/unsigned)

--- a/include/fdreadoutlibs/wib/WIBTPHandler.hpp
+++ b/include/fdreadoutlibs/wib/WIBTPHandler.hpp
@@ -68,7 +68,7 @@ public:
       tpset.seqno = m_next_tpset_seqno++; // NOLINT(runtime/increment_decrement)
       tpset.type = trigger::TPSet::Type::kPayload;
       tpset.origin = m_geoid;
-
+      
       while (!m_tp_buffer.empty() && m_tp_buffer.top().time_start < tpset.end_time) {
         triggeralgs::TriggerPrimitive tp = m_tp_buffer.top();
         types::SW_WIB_TRIGGERPRIMITIVE_STRUCT* tp_readout_type =


### PR DESCRIPTION
* This branch for EHN1 testing on 9 June 2022

* Fix bug adding TPs to TPSets

* A backup in case previous branch fails

* Add logs to track tp handler

* Adding log to track the tp raw processor

* Adding logs to tp raw processor

* Replacing TLOG() with TLOG(1)

* Adding offline channel number

* Log for offline channel number

* Fix the TP stitching for 5 links enabled

* Fixing FELIX chunk processing

* cleanup comments and re-enable tp sink

* Fixed log messages

Co-authored-by: Ivana Radoslavova Hristova <ivana.hristova@cern.ch>