### PR TITLE
Adapt FD readout types to new fw TP format in detdataformats

### DIFF
--- a/include/fdreadoutlibs/FDReadoutTypes.hpp
+++ b/include/fdreadoutlibs/FDReadoutTypes.hpp
@@ -18,7 +18,7 @@
 #include "detdataformats/wib/WIBFrame.hpp"
 #include "detdataformats/wib2/WIB2Frame.hpp"
 #include "detdataformats/tde/TDE16Frame.hpp"
-#include "detdataformats/wib/RawWIBTp.hpp"
+#include "detdataformats/fwtp/RawTp.hpp"
 #include "triggeralgs/TriggerPrimitive.hpp"
 
 #include <cstdint> // uint_t types
@@ -570,8 +570,8 @@ struct RAW_WIB_TRIGGERPRIMITIVE_STRUCT
 
 private:
 void unpack_timestamp() {
-    std::unique_ptr<detdataformats::wib::RawWIBTp> rwtp = 
-                    std::make_unique<detdataformats::wib::RawWIBTp>();
+    std::unique_ptr<detdataformats::fwtp::RawTp> rwtp = 
+                    std::make_unique<detdataformats::fwtp::RawTp>();
     ::memcpy(static_cast<void*>(&rwtp->m_head),
              static_cast<void*>(m_raw_tp_frame_chunk.data()),
              2*RAW_WIB_TP_SUBFRAME_SIZE); 

--- a/include/fdreadoutlibs/wib/RAWWIBTriggerPrimitiveProcessor.hpp
+++ b/include/fdreadoutlibs/wib/RAWWIBTriggerPrimitiveProcessor.hpp
@@ -145,8 +145,8 @@ void tp_stitch(rwtp_ptr rwtp)
   uint8_t m_slot_no = rwtp->m_head.m_slot_no; // NOLINT
   uint offline_channel = m_channel_map->get_offline_channel_from_crate_slot_fiber_chan(m_crate_no, m_slot_no, m_fiber_no, m_channel_no);
 
-  TLOG(TLVL_WORK_STEPS) << "IRHRI fwTPG enabled -- will loop over " << nhits << " hits" ;
-  TLOG(TLVL_WORK_STEPS) << "IRHRI fwTPG enabled -- offline channel " << offline_channel ;
+  TLOG_DEBUG(TLVL_WORK_STEPS) << "IRHRI fwTPG enabled -- will loop over " << nhits << " hits" ;
+  TLOG_DEBUG(TLVL_WORK_STEPS) << "IRHRI fwTPG enabled -- offline channel " << offline_channel ;
   m_nhits[nhits] += 1;
   for (int i = 0; i < nhits; i++) {
 
@@ -163,10 +163,10 @@ void tp_stitch(rwtp_ptr rwtp)
     trigprim.algorithm = triggeralgs::TriggerPrimitive::Algorithm::kTPCDefault;
     trigprim.version = 1;
 
-    TLOG(TLVL_WORK_STEPS) << "IRHRI tp_stitch time_start " << trigprim.time_start; 
-    TLOG(TLVL_WORK_STEPS) << "IRHRI tp_stitch time_peak " << trigprim.time_peak; 
-    TLOG(TLVL_WORK_STEPS) << "IRHRI tp_stitch time_over_threshold " << trigprim.time_over_threshold; 
-    TLOG(TLVL_WORK_STEPS) << "IRHRI tp_stitch channel " << trigprim.channel; 
+    TLOG_DEBUG(TLVL_WORK_STEPS) << "IRHRI tp_stitch time_start " << trigprim.time_start; 
+    TLOG_DEBUG(TLVL_WORK_STEPS) << "IRHRI tp_stitch time_peak " << trigprim.time_peak; 
+    TLOG_DEBUG(TLVL_WORK_STEPS) << "IRHRI tp_stitch time_over_threshold " << trigprim.time_over_threshold; 
+    TLOG_DEBUG(TLVL_WORK_STEPS) << "IRHRI tp_stitch channel " << trigprim.channel; 
 
     // stitch current hit to previous hit
     if (m_A[m_channel_no][m_fiber_no].size() == 1) {


### PR DESCRIPTION
The change in this PR synchronises the FD readout types with the changes in detdataformats:
https://github.com/DUNE-DAQ/detdataformats/pull/32
We now use the name `RawTp` from the namespace `fwtp`.