### PR TITLE
Hristova/fwtp stitch config

### DIFF
--- a/include/fdreadoutlibs/FDReadoutTypes.hpp
+++ b/include/fdreadoutlibs/FDReadoutTypes.hpp
@@ -18,7 +18,7 @@
 #include "detdataformats/wib/WIBFrame.hpp"
 #include "detdataformats/wib2/WIB2Frame.hpp"
 #include "detdataformats/tde/TDE16Frame.hpp"
-#include "detdataformats/wib/RawWIBTp.hpp"
+#include "detdataformats/fwtp/RawTp.hpp"
 #include "triggeralgs/TriggerPrimitive.hpp"
 
 #include <cstdint> // uint_t types
@@ -570,8 +570,8 @@ struct RAW_WIB_TRIGGERPRIMITIVE_STRUCT
 
 private:
 void unpack_timestamp() {
-    std::unique_ptr<detdataformats::wib::RawWIBTp> rwtp = 
-                    std::make_unique<detdataformats::wib::RawWIBTp>();
+    std::unique_ptr<detdataformats::fwtp::RawTp> rwtp = 
+                    std::make_unique<detdataformats::fwtp::RawTp>();
     ::memcpy(static_cast<void*>(&rwtp->m_head),
              static_cast<void*>(m_raw_tp_frame_chunk.data()),
              2*RAW_WIB_TP_SUBFRAME_SIZE); 


### PR DESCRIPTION
This PR addresses 
https://github.com/DUNE-DAQ/fdreadoutlibs/issues/24
https://github.com/DUNE-DAQ/fdreadoutlibs/issues/27
The firmware TP stitching uses the number of ticks between the packed WIB frames (64 frames in a packet).
This number was 1600 for WIB1 and 2000 for WIB2. This is now made a configurable parameter.
Each so called WIB-to-TP packet consists of 64 WIB frames, with consecutive timestamps, packed in a format suitable for the firmware TPG.
This change is requires PR 
https://github.com/DUNE-DAQ/readoutlibs/pull/46

This branch uses the new WIB2-related header change in the firmware TP frame format:
https://github.com/DUNE-DAQ/detdataformats/tree/jbrooke/fw_tp_update

FD readout types are synchronised with the changes in detdataformats, where we now use the name RawTp from the namespace fwtp. This change requires PR
https://github.com/DUNE-DAQ/detdataformats/pull/32

This PR supercedes the previous 
https://github.com/DUNE-DAQ/fdreadoutlibs/pull/34
https://github.com/DUNE-DAQ/fdreadoutlibs/pull/33
https://github.com/DUNE-DAQ/fdreadoutlibs/pull/32