### PR TITLE
Updated WIB2 frame size in emulator mode in WIB2FrameProcessor

### DIFF
--- a/src/wib2/WIB2FrameProcessor.cpp
+++ b/src/wib2/WIB2FrameProcessor.cpp
@@ -38,7 +38,7 @@ WIB2FrameProcessor::timestamp_check(frameptr fp)
   if (inherited::m_emulator_mode) {         // emulate perfectly incrementing timestamp
     uint64_t ts_next = m_previous_ts + 384; // NOLINT(build/unsigned)
     for (unsigned int i = 0; i < 12; ++i) { // NOLINT(build/unsigned)
-      auto wf = reinterpret_cast<dunedaq::detdataformats::wib2::WIB2Frame*>(((uint8_t*)fp) + i * 468); // NOLINT
+      auto wf = reinterpret_cast<dunedaq::detdataformats::wib2::WIB2Frame*>(((uint8_t*)fp) + i * sizeof(dunedaq::detdataformats::wib2::WIB2Frame)); // NOLINT
       auto& wfh = wf->header; // const_cast<dunedaq::detdataformats::wib2::WIB2Frame::Header*>(wf->get_wib_header());
       // wfh->set_timestamp(ts_next);
       wfh.timestamp_1 = ts_next;


### PR DESCRIPTION
Without this change, I saw varying size of the fragments produced by WIB emulator mode.  
With the change, I see consistent sizes of fragments.

```
daqconf_multiru_gen -o . -s 10 -n 10 -b 10000 -a 10000 -t 1.0 --latency-buffer-size 200000 --clock-speed-hz 62500000 --use-felix --emulator-mode --frontend-type wib2 --host-ru localhost --host-df localhost 
```

```
flxlibs_emu_confgen --chunkSize 472; flx-config -d 0 load emuconfigreg_472_1_0; femu -d 0 -e; flx-config -d 1 load emuconfigreg_472_1_0; femu -d 1 -e
```