### PR TITLE
Hristova/tp format config v3.2.0

### DIFF
--- a/include/fdreadoutlibs/wib/RAWWIBTriggerPrimitiveProcessor.hpp
+++ b/include/fdreadoutlibs/wib/RAWWIBTriggerPrimitiveProcessor.hpp
@@ -61,6 +61,8 @@ public:
   void conf(const nlohmann::json& args) override
   {
     auto config = args["rawdataprocessorconf"].get<readoutlibs::readoutconfig::RawDataProcessorConf>();
+    m_sourceid.id = config.source_id;
+    m_sourceid.subsystem = types::RAW_WIB_TRIGGERPRIMITIVE_STRUCT::subsystem;
 
     m_format_version = 1;
     if (config.fwtp_format_version == 2) {
@@ -429,6 +431,8 @@ private:
   std::vector<uint64_t> m_T[256][10]; // NOLINT // keep track of last stitched start time
   std::atomic<uint64_t> m_tps_stitched { 0 }; // NOLINT
   std::atomic<uint64_t> m_tp_frames  { 0 }; // NOLINT
+  daqdataformats::SourceID m_sourceid;
+
   int m_stitch_constant { 2048 }; // number of ticks between WIB-to-TP packets
   int m_format_version { 1 };  // Format version of raw TP frames for firmware TPG
   std::vector<int> m_nhits { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };


### PR DESCRIPTION
This PR replaces https://github.com/DUNE-DAQ/fdreadoutlibs/pull/46
It is indeded to merge to develop for dunedaq-v3.2.0

Here we add the option to configure the unpacking of the raw TP frames according to the firmware TPG format. Currently
we have two fwTGP format versions, which we call "old" and "new", or alternatively, we can refer to them as "v1" and "v2".
This feature involves changes in the following packages (where the relevant PRs are made as well):
fdreadoutlibs (here)
readoutlibs
readoutmodules