### PR TITLE
Renamed the kSW_TriggerPrimitive/SW_Trigger_Primitive fragment type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(fdreadoutlibs VERSION 1.5.3)
+project(fdreadoutlibs VERSION 1.5.4)
 
 find_package(daq-cmake REQUIRED)
 

--- a/include/fdreadoutlibs/FDReadoutTypes.hpp
+++ b/include/fdreadoutlibs/FDReadoutTypes.hpp
@@ -383,7 +383,7 @@ struct SW_WIB_TRIGGERPRIMITIVE_STRUCT
   size_t get_frame_size() { return TP_SIZE; }
 
   static const constexpr daqdataformats::SourceID::Subsystem subsystem = daqdataformats::SourceID::Subsystem::kTrigger;
-  static const constexpr daqdataformats::FragmentType fragment_type = daqdataformats::FragmentType::kSW_TriggerPrimitive;
+  static const constexpr daqdataformats::FragmentType fragment_type = daqdataformats::FragmentType::kTriggerPrimitive;
   static const constexpr uint64_t expected_tick_difference = 25; // NOLINT(build/unsigned)
 };
 
@@ -433,7 +433,7 @@ struct SW_WIB2_TRIGGERPRIMITIVE_STRUCT
   size_t get_frame_size() { return TP_SIZE_WIB2; }
 
   static const constexpr daqdataformats::SourceID::Subsystem subsystem = daqdataformats::SourceID::Subsystem::kTrigger;
-  static const constexpr daqdataformats::FragmentType fragment_type = daqdataformats::FragmentType::kSW_TriggerPrimitive;
+  static const constexpr daqdataformats::FragmentType fragment_type = daqdataformats::FragmentType::kTriggerPrimitive;
   static const constexpr uint64_t expected_tick_difference = 25; // NOLINT(build/unsigned)
 };
 


### PR DESCRIPTION
…to just kTriggerPrimitive/Trigger_Primitive.

These changes are correlated with changes in other repositories, and they need to be tested and merged together. I will add a comment with the full list of repos in a little while