### PR TITLE
Removed enum CollectionOrInduction and updated README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,12 +10,12 @@ The following frontends and features are provided by this package:
 * *Daphne*: Frame processor and request handler to be used with the SkipList latency buffer.
 * *SSP*: Only frame processor
 * *WIB*: Frame processor for `WIB`, software and hardware `WIB` TPs. Implementation of avx based software hit finding (software tpg) for `WIB`
-* *WIB2*: Only frame processor
+* *WIB2*: Frame processor for `WIB2`, implementation of avx based software hit finding (software tpg) for `WIB2`
 
 
 # Test Software TPG on WIB2
 
-To test the execution of the DUNE WIB2 software TPG, first download a raw data file, either by running `wget https://www.dropbox.com/s/9b1xtkjbkfyakij/frames_wib2.bin` or clicking on the [CERNBox link](https://www.dropbox.com/s/9b1xtkjbkfyakij/frames_wib2.bin) and put it into `<work_dir>`                                                                                             
+To test the execution of the DUNE WIB2 software TPG, first download a raw data file, either by running `curl https://cernbox.cern.ch/index.php/s/ocrHxSU8PucxphE/download -o wib2-frames.bin` or clicking on the [CERNBox link](https://cernbox.cern.ch/index.php/s/ocrHxSU8PucxphE/download) and put it into `<work_dir>`                                                                                             
 
 Example of `daqconf` configuration file used for testing:
 
@@ -28,7 +28,7 @@ Example of `daqconf` configuration file used for testing:
 "readout": {
    "enable_software_tpg": true,
    "clock_speed_hz": 62500000,
-   "data_file": "./frames_wib2.bin",
+   "data_file": "./wib2-frames.bin",
    "readout_sends_tp_fragments": false
 },
 

--- a/include/fdreadoutlibs/FDReadoutTypes.hpp
+++ b/include/fdreadoutlibs/FDReadoutTypes.hpp
@@ -646,11 +646,6 @@ struct TpSubframe
   uint32_t word3; // NOLINT(build/unsigned)
 };
 
-enum CollectionOrInduction {
-  kCollection,
-  kInduction
-};
-
 
 } // namespace types
 } // namespace fdreadoutlibs

--- a/include/fdreadoutlibs/wib2/WIB2FrameProcessor.hpp
+++ b/include/fdreadoutlibs/wib2/WIB2FrameProcessor.hpp
@@ -52,8 +52,14 @@ using dunedaq::readoutlibs::logging::TLVL_BOOKKEEPING;
 using dunedaq::readoutlibs::logging::TLVL_TAKE_NOTE;
 
 
+
 namespace dunedaq {
 namespace fdreadoutlibs {
+
+enum WIB2CollectionOrInduction {
+  kCollection,
+  kInduction
+};
 
 class WIB2FrameProcessor : public readoutlibs::TaskRawDataProcessorModel<types::WIB2_SUPERCHUNK_STRUCT>
 {
@@ -489,7 +495,7 @@ protected:
     *m_coll_primfind_dest = swtpg_wib2::MAGIC;
     swtpg_wib2::process_window_avx2(*m_coll_tpg_pi);
 
-    unsigned int nhits = add_hits_to_tphandler(m_coll_primfind_dest, timestamp, types::kCollection);
+    unsigned int nhits = add_hits_to_tphandler(m_coll_primfind_dest, timestamp, kCollection);
 
     if (nhits > 0) {
        TLOG_DEBUG(0) << "Non null collection hits: " << nhits << " for ts: " << timestamp;
@@ -512,7 +518,7 @@ protected:
       // std::this_thread::sleep_for(std::chrono::microseconds(100));
     }
 
-    m_num_hits_ind += add_hits_to_tphandler(m_ind_primfind_dest, timestamp, types::kInduction);
+    m_num_hits_ind += add_hits_to_tphandler(m_ind_primfind_dest, timestamp, kInduction);
 
     if (m_num_hits_ind > 0) {
        TLOG_DEBUG(2) << "NON null induction hits: " << m_num_hits_ind << " for ts: " << timestamp;
@@ -579,7 +585,7 @@ protected:
     TLOG() << "Induction hit-finding thread stopping after processing " << n_items << " frames";
   }
 
-  unsigned int add_hits_to_tphandler(uint16_t* primfind_it, timestamp_t timestamp, types::CollectionOrInduction coll_or_ind)
+  unsigned int add_hits_to_tphandler(uint16_t* primfind_it, timestamp_t timestamp, WIB2CollectionOrInduction coll_or_ind)
   {
 
     constexpr int clocksPerTPCTick = 32;
@@ -624,7 +630,7 @@ protected:
       for (int i = 0; i < 16; ++i) {
         if (hit_charge[i] && chan[i] != swtpg_wib2::MAGIC) {
           // This channel had a hit ending here, so we can create and output the hit here
-          const uint16_t offline_channel = (coll_or_ind == types::kCollection) ?
+          const uint16_t offline_channel = (coll_or_ind == kCollection) ?
             m_register_channel_map.collection[chan[i]] : m_register_channel_map.induction[chan[i]];
           uint64_t tp_t_begin =                                                        // NOLINT(build/unsigned)
             timestamp + clocksPerTPCTick * (int64_t(hit_end[i]) - hit_tover[i]);       // NOLINT(build/unsigned)


### PR DESCRIPTION
As requested, I removed the `enum CollectionOrInduction` from the `FDReadoutTypes` and added it to the `WIB2FrameProcessor`. 
I also updated the README file with the new location of the WIB2 frame file (changed from dropbox to cernbox). 
Compiled and tested on np04-srv-019. 