### PR TITLE
Hristova/patch for v3.2.2

### DIFF
--- a/include/fdreadoutlibs/wib2/RAWWIBTriggerPrimitiveProcessor.hpp
+++ b/include/fdreadoutlibs/wib2/RAWWIBTriggerPrimitiveProcessor.hpp
@@ -341,8 +341,8 @@ void tp_unpack(frame_ptr fr)
       return;
     }
     // Quick timestamp check to discard chunks with bad header
-    uint32_t ts1 = reinterpret_cast<types::TpSubframe*>(((uint8_t*)srcbuffer.data())+ offset)->word1;
-    uint32_t ts2 = reinterpret_cast<types::TpSubframe*>(((uint8_t*)srcbuffer.data())+ offset)->word2;
+    uint32_t ts1 = reinterpret_cast<types::TpSubframe*>(((uint8_t*)srcbuffer.data())+ offset)->word2;
+    uint32_t ts2 = reinterpret_cast<types::TpSubframe*>(((uint8_t*)srcbuffer.data())+ offset)->word3;
     uint64_t ts = (ts1 & 0xFFFF0000) >> 16;
     ts += static_cast<int64_t>(ts1 & 0xFFFF) << 16;
     ts += static_cast<int64_t>(ts2 & 0xFFFF0000) << 16;

--- a/include/fdreadoutlibs/wib2/RAWWIBTriggerPrimitiveProcessor.hpp
+++ b/include/fdreadoutlibs/wib2/RAWWIBTriggerPrimitiveProcessor.hpp
@@ -326,7 +326,7 @@ void tp_unpack(frame_ptr fr)
  
     auto now = std::chrono::high_resolution_clock::now();
     // Count number of subframes in a TP frame
-    int n;
+    int n=2;
     bool ped_found { false };
     for (n=2; offset + n * RAW_WIB_TP_SUBFRAME_SIZE<(size_t)num_elem; ++n) {
       if (reinterpret_cast<types::TpSubframe*>(((uint8_t*)srcbuffer.data()) // NOLINT
@@ -337,13 +337,13 @@ void tp_unpack(frame_ptr fr)
     }
     // Found no pedestal block
     if (!ped_found) {
-      TLOG() << "Debug message: Raw WIB TP chunk contains no TP frames! Chunk size is " << num_elem;
+      TLOG() << "Debug message: Raw WIB TP chunk contains no TP frames! Chunk size / offset / n is " << num_elem << " / " << offset << " / " << n;
       return;
     }
     // Found pedestal block without hit block
-    if (n < 3) {
-      TLOG() << "Debug message: Raw WIB TP chunk contains no TP hits! Chunk size is " << num_elem;
-      return;
+    if (n < 3 && offset !=0) {
+      TLOG_DEBUG(20) << "Debug message: Raw WIB TP chunk contains no TP hits! Chunk size / offset / n is " << num_elem << " / " << offset << " / " << n;
+      //return;
     }
     // Quick timestamp check to discard chunks with bad header
     uint32_t ts1 = reinterpret_cast<types::TpSubframe*>(((uint8_t*)srcbuffer.data())+ offset)->word1;
@@ -363,8 +363,8 @@ void tp_unpack(frame_ptr fr)
     double hour = std::chrono::seconds(360).count();
     // Check if time in header is within reasonable limits
     if (ts_epoch > ts_now || ts_epoch < ts_now - hour) {
-      TLOG() << "Debug message: Raw WIB TP frame contains no real timestamp! Chunk size is " << num_elem;
-      return;
+      TLOG_DEBUG(20) << "Debug message: Raw WIB TP frame contains no real timestamp! Chunk size is " << num_elem;
+      //return;
     }
 
     int bsize = n * RAW_WIB_TP_SUBFRAME_SIZE;

--- a/include/fdreadoutlibs/wib2/RAWWIBTriggerPrimitiveProcessor.hpp
+++ b/include/fdreadoutlibs/wib2/RAWWIBTriggerPrimitiveProcessor.hpp
@@ -326,16 +326,18 @@ void tp_unpack(frame_ptr fr)
  
     auto now = std::chrono::high_resolution_clock::now();
     // Count number of subframes in a TP frame
-    int n = 1;
+    int n;
     bool ped_found { false };
-    for (n=1; offset+(n-1)*RAW_WIB_TP_SUBFRAME_SIZE<(size_t)num_elem; ++n) {
+    for (n=2; offset + n * RAW_WIB_TP_SUBFRAME_SIZE<(size_t)num_elem; ++n) {
       if (reinterpret_cast<types::TpSubframe*>(((uint8_t*)srcbuffer.data()) // NOLINT
-           + offset + (n-1)*RAW_WIB_TP_SUBFRAME_SIZE)->word3 == 0xDEADBEEF) {
+           + offset + n*RAW_WIB_TP_SUBFRAME_SIZE)->word3 == 0xDEADBEEF) {
         ped_found = true;
         break; 
       }  
     }
     if (!ped_found) return;
+
+    if (n < 3) return;
 
     int bsize = n * RAW_WIB_TP_SUBFRAME_SIZE;
     std::vector<char> tmpbuffer;

--- a/include/fdreadoutlibs/wib2/RAWWIBTriggerPrimitiveProcessor.hpp
+++ b/include/fdreadoutlibs/wib2/RAWWIBTriggerPrimitiveProcessor.hpp
@@ -340,27 +340,6 @@ void tp_unpack(frame_ptr fr)
       TLOG() << "Debug message: Raw WIB TP chunk contains no TP frames! Chunk size / offset / subframes is " << num_elem << " / " << offset << " / " << n;
       return;
     }
-    // Quick timestamp check to discard chunks with bad header
-    uint32_t ts1 = reinterpret_cast<types::TpSubframe*>(((uint8_t*)srcbuffer.data())+ offset)->word2;
-    uint32_t ts2 = reinterpret_cast<types::TpSubframe*>(((uint8_t*)srcbuffer.data())+ offset)->word3;
-    uint64_t ts = (ts1 & 0xFFFF0000) >> 16;
-    ts += static_cast<int64_t>(ts1 & 0xFFFF) << 16;
-    ts += static_cast<int64_t>(ts2 & 0xFFFF0000) << 16;
-    ts += static_cast<int64_t>(ts2 & 0xFFFF) << 48;
-    // Convert DUNE timestamp to UNIX timestamp
-    double ts_epoch = ts*0.000000016; // 16ns = 1/62.5MHz where 62.5MHz is the clock frequency
-    // Convert current time to seconds
-    auto ts_sys = std::chrono::system_clock::now();
-    auto ts_sec = std::chrono::duration<double>(ts_sys.time_since_epoch());
-    double ts_now = ts_sec.count();
-    // Period duration in seconds
-    double day = std::chrono::seconds(86400).count();
-    double hour = std::chrono::seconds(360).count();
-    // Check if time in header is within reasonable limits
-    if (ts_epoch > ts_now || ts_epoch < ts_now - hour) {
-      TLOG_DEBUG(20) << "Debug message: Raw WIB TP frame contains no real timestamp! Chunk size is " << num_elem;
-      return;
-    }
 
     int bsize = n * RAW_WIB_TP_SUBFRAME_SIZE;
     std::vector<char> tmpbuffer;

--- a/include/fdreadoutlibs/wib2/RAWWIBTriggerPrimitiveProcessor.hpp
+++ b/include/fdreadoutlibs/wib2/RAWWIBTriggerPrimitiveProcessor.hpp
@@ -353,7 +353,7 @@ void tp_unpack(frame_ptr fr)
     ts += static_cast<int64_t>(ts2 & 0xFFFF0000) << 16;
     ts += static_cast<int64_t>(ts2 & 0xFFFF) << 48;
     // Convert DUNE timestamp to UNIX timestamp
-    double ts_epoch = ts*0.000000016;
+    double ts_epoch = ts*0.000000016; // 16ns = 1/62.5MHz where 62.5MHz is the clock frequency
     // Convert current time to seconds
     auto ts_sys = std::chrono::system_clock::now();
     auto ts_sec = std::chrono::duration<double>(ts_sys.time_since_epoch());

--- a/include/fdreadoutlibs/wib2/RAWWIBTriggerPrimitiveProcessor.hpp
+++ b/include/fdreadoutlibs/wib2/RAWWIBTriggerPrimitiveProcessor.hpp
@@ -21,6 +21,7 @@
 #include "detchannelmaps/TPCChannelMap.hpp"
 #include "fdreadoutlibs/wib2/WIB2TPHandler.hpp"
 #include "fdreadoutlibs/DUNEWIBFirmwareTriggerPrimitiveSuperChunkTypeAdapter.hpp"
+#include "fdreadoutlibs/TriggerPrimitiveTypeAdapter.hpp"
 #include "rcif/cmd/Nljs.hpp"
 #include "triggeralgs/TriggerPrimitive.hpp"
 #include "trigger/TPSet.hpp"
@@ -62,6 +63,8 @@ public:
   void conf(const nlohmann::json& args) override
   {
     auto config = args["rawdataprocessorconf"].get<readoutlibs::readoutconfig::RawDataProcessorConf>();
+    m_sourceid.id = config.source_id;
+    m_sourceid.subsystem = types::DUNEWIBFirmwareTriggerPrimitiveSuperChunkTypeAdapter::subsystem;
 
     TaskRawDataProcessorModel<types::DUNEWIBFirmwareTriggerPrimitiveSuperChunkTypeAdapter>::add_preprocess_task(
                 std::bind(&RAWWIBTriggerPrimitiveProcessor::tp_unpack, this, std::placeholders::_1));


### PR DESCRIPTION
Following the call for post Integration Week patches, this branch was prepared with the aim to be included in the dunedaq-v3.2.2 release. 

It contains changes to the FW TPG unpacking process which have been tested shortly after the integration week, but using the 
same setup as used during that week. 

The main but minor improvement is in the way the loop over TP frames is done, now it handles very rare edge cases and is supposed to be faster: 
- Previously the size parameter to memcpy could become negative thus overlaying of memory may occur.
- The loop reflects the TP frame structure and thus performs fewer iterations when parsing the input data block in the majority of the cases.   

In addition, the Source ID is retrieved in the same way as in the SW TPG. This changes was made to help fix the Source ID issue  
https://github.com/DUNE-DAQ/fdreadoutlibs/issues/72
however the ultimate fix to this problem is provided in https://github.com/DUNE-DAQ/daqconf/pull/267

These changes were tested in a WIB pulser run in December 2022.

  