### PR TITLE
WIB2TPHandler - use shared pointers instead of references

### DIFF
--- a/include/fdreadoutlibs/wib2/RAWWIBTriggerPrimitiveProcessor.hpp
+++ b/include/fdreadoutlibs/wib2/RAWWIBTriggerPrimitiveProcessor.hpp
@@ -76,7 +76,7 @@ public:
       tpset_sourceid.id = config.tpset_sourceid;
       tpset_sourceid.subsystem = daqdataformats::SourceID::Subsystem::kTrigger;
       m_tphandler.reset(
-            new WIB2TPHandler(*m_tp_sink, *m_tpset_sink, config.tp_timeout, config.tpset_window_size, tpset_sourceid));
+            new WIB2TPHandler(m_tp_sink, m_tpset_sink, config.tp_timeout, config.tpset_window_size, tpset_sourceid));
     }
 
     m_channel_map = dunedaq::detchannelmaps::make_map(config.channel_map_name);

--- a/include/fdreadoutlibs/wib2/WIB2FrameProcessor.hpp
+++ b/include/fdreadoutlibs/wib2/WIB2FrameProcessor.hpp
@@ -292,7 +292,7 @@ public:
 
 
       m_tphandler.reset(
-        new WIB2TPHandler(*m_tp_sink, *m_tpset_sink, config.tp_timeout, config.tpset_window_size, tpset_sourceid));
+        new WIB2TPHandler(m_tp_sink, m_tpset_sink, config.tp_timeout, config.tpset_window_size, tpset_sourceid));
 
 
       TaskRawDataProcessorModel<types::DUNEWIBSuperChunkTypeAdapter>::add_postprocess_task(

--- a/include/fdreadoutlibs/wib2/WIB2TPHandler.hpp
+++ b/include/fdreadoutlibs/wib2/WIB2TPHandler.hpp
@@ -34,8 +34,8 @@ namespace fdreadoutlibs {
 class WIB2TPHandler
 {
 public:
-  explicit WIB2TPHandler(iomanager::SenderConcept<types::TriggerPrimitiveTypeAdapter>& tp_sink,
-                        iomanager::SenderConcept<trigger::TPSet>& tpset_sink,
+  explicit WIB2TPHandler(std::shared_ptr<iomanager::SenderConcept<types::TriggerPrimitiveTypeAdapter>> tp_sink,
+                        std::shared_ptr<iomanager::SenderConcept<trigger::TPSet>> tpset_sink,
                         uint64_t tp_timeout,        // NOLINT(build/unsigned)
                         uint64_t tpset_window_size, // NOLINT(build/unsigned)
                         daqdataformats::SourceID sourceId)
@@ -77,32 +77,36 @@ public:
       tpset.type = trigger::TPSet::Type::kPayload;
       tpset.origin = m_sourceid;
       
-      while (!m_tp_buffer.empty() && m_tp_buffer.top().time_start < tpset.end_time) {
-        triggeralgs::TriggerPrimitive tp = m_tp_buffer.top();
-        types::TriggerPrimitiveTypeAdapter* tp_readout_type =
-          reinterpret_cast<types::TriggerPrimitiveTypeAdapter*>(&tp); // NOLINT
-        try {
-            types::TriggerPrimitiveTypeAdapter tp_copy(*tp_readout_type);
-          m_tp_sink.send(std::move(tp_copy), std::chrono::milliseconds(10));
-          m_sent_tps++;
-        } catch (const dunedaq::iomanager::TimeoutExpired& excpt) {
-          ers::error(readoutlibs::CannotWriteToQueue(ERS_HERE, m_sourceid, "m_tp_sink"));
+      if (m_tp_sink) {
+        while (!m_tp_buffer.empty() && m_tp_buffer.top().time_start < tpset.end_time) {
+          triggeralgs::TriggerPrimitive tp = m_tp_buffer.top();
+          types::TriggerPrimitiveTypeAdapter* tp_readout_type =
+            reinterpret_cast<types::TriggerPrimitiveTypeAdapter*>(&tp); // NOLINT
+          try {
+              types::TriggerPrimitiveTypeAdapter tp_copy(*tp_readout_type);
+            m_tp_sink->send(std::move(tp_copy), std::chrono::milliseconds(10));
+            m_sent_tps++;
+          } catch (const dunedaq::iomanager::TimeoutExpired& excpt) {
+            ers::error(readoutlibs::CannotWriteToQueue(ERS_HERE, m_sourceid, "m_tp_sink"));
+          }
+          tpset.objects.emplace_back(std::move(tp));
+          m_tp_buffer.pop();
         }
-        tpset.objects.emplace_back(std::move(tp));
-        m_tp_buffer.pop();
       }
 
-      if (tpset.start_time < m_timestamp_counter) {
-        ers::warning(TPHandlerTimestampIssue(ERS_HERE, tpset.start_time, m_timestamp_counter));        
-        return;
-      }
-      try {
-        m_tpset_sink.send(std::move(tpset), std::chrono::milliseconds(10));
-        m_sent_tpsets++;
-        m_timestamp_counter = tpset.start_time;        
-      } catch (const dunedaq::iomanager::TimeoutExpired& excpt) {
-        ers::error(readoutlibs::CannotWriteToQueue(ERS_HERE, m_sourceid, "m_tpset_sink"));
-      }      
+      if (m_tpset_sink) {
+        if (tpset.start_time < m_timestamp_counter) {
+          ers::warning(TPHandlerTimestampIssue(ERS_HERE, tpset.start_time, m_timestamp_counter));        
+          return;
+        }
+        try {
+          m_tpset_sink->send(std::move(tpset), std::chrono::milliseconds(10));
+          m_sent_tpsets++;
+          m_timestamp_counter = tpset.start_time;        
+        } catch (const dunedaq::iomanager::TimeoutExpired& excpt) {
+          ers::error(readoutlibs::CannotWriteToQueue(ERS_HERE, m_sourceid, "m_tpset_sink"));
+        }    
+      }  
     }
   }
 
@@ -122,8 +126,8 @@ public:
   size_t get_and_reset_num_sent_tpsets() { return m_sent_tpsets.exchange(0); }
 
 private:
-  iomanager::SenderConcept<types::TriggerPrimitiveTypeAdapter>& m_tp_sink;
-  iomanager::SenderConcept<trigger::TPSet>& m_tpset_sink;
+  std::shared_ptr<iomanager::SenderConcept<types::TriggerPrimitiveTypeAdapter>> m_tp_sink;
+  std::shared_ptr<iomanager::SenderConcept<trigger::TPSet>> m_tpset_sink;
   daqdataformats::run_number_t m_run_number{ daqdataformats::TypeDefaults::s_invalid_run_number };
   uint64_t m_tp_timeout;           // NOLINT(build/unsigned)
   uint64_t m_tpset_window_size;    // NOLINT(build/unsigned)


### PR DESCRIPTION
The `WIB2TPHandler` keeps a reference to `SenderConcept` to send TPs and TPSets out.
In cases where one of these outputs is not connected (e.g. no TP datalink handler connected to `tp_out), the `WIB2TPHandler` crashes when trying to send objects out.
This is easily solvable by moving to use shared pointers to the same `SenderConcept`s with little effort, as the `SenderConcept`s are returned bt `IOManager` as shared pointers.

The change is applied in this PR, and an additional check added to the try_send method, to proceed with the sending only if the relevant shared pointer is not `null`