### PR TITLE
moved the crate/slot/link validation in WIB2FrameProcessor from the f…

### DIFF
--- a/include/fdreadoutlibs/wib2/WIB2FrameProcessor.hpp
+++ b/include/fdreadoutlibs/wib2/WIB2FrameProcessor.hpp
@@ -104,8 +104,7 @@ public:
   // Map from expanded AVX register position to offline channel number
   swtpg_wib2::RegisterChannelMap register_channel_map; 
 
-  bool first_hit = true;
-  bool first_timestamp_check = true;
+  bool m_first_hit = true;
 
   int get_registers_selector();
 
@@ -157,6 +156,7 @@ protected:
   dunedaq::daqdataformats::timestamp_t m_pattern_generator_previous_ts = 0;
   dunedaq::daqdataformats::timestamp_t m_pattern_generator_current_ts = 0;
 
+  bool m_first_timestamp_check = true;
   bool m_first_ts_missmatch = true;
   bool m_problem_reported = false;
   std::atomic<int> m_ts_error_ctr{ 0 };

--- a/include/fdreadoutlibs/wib2/WIB2FrameProcessor.hpp
+++ b/include/fdreadoutlibs/wib2/WIB2FrameProcessor.hpp
@@ -104,8 +104,9 @@ public:
   // Map from expanded AVX register position to offline channel number
   swtpg_wib2::RegisterChannelMap register_channel_map; 
 
-  bool first_hit = true;                                                  
-                                                  
+  bool first_hit = true;
+  bool first_timestamp_check = true;
+
   int get_registers_selector();
 
   void reset();


### PR DESCRIPTION
…ind_hits method to the timestamp_check method, as suggested by Giovanna