### PR TITLE
Sequence id error monitoring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(fdreadoutlibs VERSION 1.7.1)
+project(fdreadoutlibs VERSION 1.7.2)
 
 find_package(daq-cmake REQUIRED)
 

--- a/include/fdreadoutlibs/DAPHNEStreamSuperChunkTypeAdapter.hpp
+++ b/include/fdreadoutlibs/DAPHNEStreamSuperChunkTypeAdapter.hpp
@@ -79,7 +79,7 @@ namespace dunedaq::fdreadoutlibs::types {
     constexpr size_t get_frame_size() const { return kDAPHNEStreamFrameSize; }
 
     static const constexpr daqdataformats::SourceID::Subsystem subsystem = daqdataformats::SourceID::Subsystem::kDetectorReadout;
-    static const constexpr daqdataformats::FragmentType fragment_type = daqdataformats::FragmentType::kDAPHNE;
+    static const constexpr daqdataformats::FragmentType fragment_type = daqdataformats::FragmentType::kDAPHNEStream;
     static const constexpr uint64_t expected_tick_difference = 64; // NOLINT(build/unsigned)    
   };
 

--- a/include/fdreadoutlibs/wibeth/WIBEthFrameProcessor.hpp
+++ b/include/fdreadoutlibs/wibeth/WIBEthFrameProcessor.hpp
@@ -139,6 +139,8 @@ protected:
   bool m_first_seq_id_mismatch = true;
   bool m_seq_id_problem_reported = false;
   std::atomic<uint64_t> m_seq_id_error_ctr{ 0 };
+  std::atomic<int16_t> m_seq_id_min_jump{ 0 };
+  std::atomic<int16_t> m_seq_id_max_jump{ 0 };
 
   /**
    * Pipeline Stage 0: Pattern generator for hit finding in emulated mode

--- a/include/fdreadoutlibs/wibeth/WIBEthFrameProcessor.hpp
+++ b/include/fdreadoutlibs/wibeth/WIBEthFrameProcessor.hpp
@@ -126,12 +126,19 @@ protected:
   dunedaq::daqdataformats::timestamp_t m_previous_ts = 0;
   dunedaq::daqdataformats::timestamp_t m_current_ts = 0;
 
+  uint16_t m_previous_seq_id = 0;
+  uint16_t m_current_seq_id = 0;
+
   dunedaq::daqdataformats::timestamp_t m_pattern_generator_previous_ts = 0;
   dunedaq::daqdataformats::timestamp_t m_pattern_generator_current_ts = 0;
 
   bool m_first_ts_missmatch = true;
-  bool m_problem_reported = false;
-  std::atomic<int> m_ts_error_ctr{ 0 };
+  bool m_ts_problem_reported = false;
+  std::atomic<uint64_t> m_ts_error_ctr{ 0 };
+
+  bool m_first_seq_id_mismatch = true;
+  bool m_seq_id_problem_reported = false;
+  std::atomic<uint64_t> m_seq_id_error_ctr{ 0 };
 
   /**
    * Pipeline Stage 0: Pattern generator for hit finding in emulated mode
@@ -139,7 +146,15 @@ protected:
   void use_pattern_generator(frameptr fp);
 
   /**
-   * Pipeline Stage 1.: Check proper timestamp increments in WIB frame
+   * Pipeline Stage 1.: Check proper sequence id increments in DAQ Eth header
+   * */
+
+
+  void sequence_check(frameptr fp);
+
+
+  /**
+   * Pipeline Stage 1.: Check proper timestamp increments in DAQ Eth header
    * */
 
 

--- a/src/wibeth/WIBEthFrameProcessor.cpp
+++ b/src/wibeth/WIBEthFrameProcessor.cpp
@@ -252,11 +252,11 @@ WIBEthFrameProcessor::get_info(opmonlib::InfoCollector& ci, int level)
 {
   readoutlibs::readoutinfo::RawDataProcessorInfo info;
 
-  info.num_seq_id_errors = m_seq_id_error_ctr.exchange(0);
+  info.num_seq_id_errors = m_seq_id_error_ctr.load();
   info.min_seq_id_jump = m_seq_id_min_jump.exchange(0);
   info.max_seq_id_jump = m_seq_id_max_jump.exchange(0);
 
-  info.num_ts_errors = m_ts_error_ctr.exchange(0);
+  info.num_ts_errors = m_ts_error_ctr.load();
   
 
   auto now = std::chrono::high_resolution_clock::now();


### PR DESCRIPTION
This PR introduces sequence id monitoring in the `WIBEthFrameProcessor`
1. adds `sequence_check` method, register as preprocessor task continuously checking the continuity of sequence id in incoming data frames, and tracking minimal and maximum deviations
2. Pushes these quantities to opmon