### PR TITLE
Remove ADC generation from FrameProcessor 

### DIFF
--- a/include/fdreadoutlibs/DAPHNEStreamSuperChunkTypeAdapter.hpp
+++ b/include/fdreadoutlibs/DAPHNEStreamSuperChunkTypeAdapter.hpp
@@ -57,6 +57,10 @@ namespace dunedaq::fdreadoutlibs::types {
     void fake_geoid(uint16_t /*crate_id*/, uint16_t /*slot_id*/, uint16_t /*link_id*/) {
     }
 
+    void fake_adc_pattern(int /*channel*/) {
+    }
+
+
     void fake_frame_errors(std::vector<uint16_t>* /*fake_errors*/) // NOLINT                                                
     {
       // Set frame error bits in header                                                                                     

--- a/include/fdreadoutlibs/DAPHNESuperChunkTypeAdapter.hpp
+++ b/include/fdreadoutlibs/DAPHNESuperChunkTypeAdapter.hpp
@@ -67,6 +67,9 @@ struct DAPHNESuperChunkTypeAdapter
       }
   }
 
+  void fake_adc_pattern(int /*channel*/) {
+  }
+
   void fake_frame_errors(std::vector<uint16_t>* /*fake_errors*/) // NOLINT
   {
     // Set frame error bits in header

--- a/include/fdreadoutlibs/DUNEWIBEthTypeAdapter.hpp
+++ b/include/fdreadoutlibs/DUNEWIBEthTypeAdapter.hpp
@@ -59,6 +59,13 @@ struct DUNEWIBEthTypeAdapter
       }
   }
 
+  void fake_adc_pattern(int channel) {
+    auto frame = reinterpret_cast<FrameType*>(&data); // NOLINT
+    // Set the ADC to the uint16 maximum value 
+    // AAA: setting only the first time sample
+    frame->set_adc(channel, 0, 16383);
+  }
+
   void fake_frame_errors(std::vector<uint16_t>* /*fake_errors*/) // NOLINT
   {
     // Set error bits in header

--- a/include/fdreadoutlibs/DUNEWIBSuperChunkTypeAdapter.hpp
+++ b/include/fdreadoutlibs/DUNEWIBSuperChunkTypeAdapter.hpp
@@ -65,6 +65,11 @@ struct DUNEWIBSuperChunkTypeAdapter
       }
   }
 
+  void fake_adc_pattern(int channel) {
+    auto frame = reinterpret_cast<dunedaq::fddetdataformats::WIB2Frame*>(&data); // NOLINT
+    frame->set_adc(channel, 16383);    
+  }
+
   void fake_frame_errors(std::vector<uint16_t>* /*fake_errors*/) // NOLINT
   {
     // Set error bits in header

--- a/include/fdreadoutlibs/ProtoWIBSuperChunkTypeAdapter.hpp
+++ b/include/fdreadoutlibs/ProtoWIBSuperChunkTypeAdapter.hpp
@@ -66,6 +66,9 @@ struct ProtoWIBSuperChunkTypeAdapter
         df->get_wib_header()->fiber_no = link_id;
       }
   }  
+
+  void fake_adc_pattern(int /*channel*/) {}
+
   void fake_frame_errors(std::vector<uint16_t>* fake_errors) // NOLINT(build/unsigned)
   {
     auto wf = reinterpret_cast<dunedaq::fddetdataformats::WIBFrame*>(((uint8_t*)(&data))); // NOLINT

--- a/include/fdreadoutlibs/SSPFrameTypeAdapter.hpp
+++ b/include/fdreadoutlibs/SSPFrameTypeAdapter.hpp
@@ -64,6 +64,9 @@ struct SSPFrameTypeAdapter
   void fake_geoid(uint16_t /*crate_id*/, uint16_t /*slot_id*/, uint16_t /*link_id*/) {
   } 
 
+  void fake_adc_pattern(int /*channel*/) {
+  }
+
   FrameType* begin() { return this; }
 
   FrameType* end() { return (this + 1); } // NOLINT

--- a/include/fdreadoutlibs/TDEFrameTypeAdapter.hpp
+++ b/include/fdreadoutlibs/TDEFrameTypeAdapter.hpp
@@ -59,6 +59,10 @@ struct TDEFrameTypeAdapter
 	//df->get_tde_header()->channel = link_id;
       }
   }
+
+  void fake_adc_pattern(int /*channel*/) {
+  }
+
   void fake_frame_errors(std::vector<uint16_t>* /*fake_errors*/) // NOLINT(build/unsigned)
   {
   }

--- a/include/fdreadoutlibs/TriggerPrimitiveTypeAdapter.hpp
+++ b/include/fdreadoutlibs/TriggerPrimitiveTypeAdapter.hpp
@@ -50,6 +50,8 @@ struct TriggerPrimitiveTypeAdapter
 
   void fake_geoid(uint16_t /*crate_id*/, uint16_t /*slot_id*/, uint16_t /*link_id*/) {}
 
+  void fake_adc_pattern(int /*channel*/) {}
+
   FrameType* begin() { return this; }
 
   FrameType* end() { return (this + 1); } // NOLINT

--- a/include/fdreadoutlibs/wib2/WIB2FrameProcessor.hpp
+++ b/include/fdreadoutlibs/wib2/WIB2FrameProcessor.hpp
@@ -42,31 +42,6 @@
 namespace dunedaq {
 namespace fdreadoutlibs {
 
-// Pattern generator class for creating different types of TP patterns
-// AAA: at the moment the pattern generator is very simple: random source id and random channel
-class WIB2PatternGenerator {
-
-public:
-  WIB2PatternGenerator() {
-    m_size = 1000000;
-  };
-  ~WIB2PatternGenerator() {};
-
-  void generate(int);
-
-  std::vector<int> get_channels() {
-    return m_channel;
-  }
-
-  int get_total_size() {
-    return m_size;
-  }
- 
-private: 
-  int m_size;
-  std::vector<int> m_channel;
-};
-
 class WIB2FrameHandler {
 
 public: 
@@ -126,17 +101,10 @@ protected:
   dunedaq::daqdataformats::timestamp_t m_previous_ts = 0;
   dunedaq::daqdataformats::timestamp_t m_current_ts = 0;
 
-  dunedaq::daqdataformats::timestamp_t m_pattern_generator_previous_ts = 0;
-  dunedaq::daqdataformats::timestamp_t m_pattern_generator_current_ts = 0;
-
   bool m_first_ts_missmatch = true;
   bool m_problem_reported = false;
   std::atomic<int> m_ts_error_ctr{ 0 };
 
-  /**
-   * Pipeline Stage 1: Pattern generator for hit finding in emulated mode
-   * */
-  void use_pattern_generator(frameptr fp);
 
   /**
    * Pipeline Stage 1.: Check proper timestamp increments in WIB frame
@@ -190,11 +158,6 @@ private:
  
   //WIB2FrameHandler m_wib2_frame_handler;
   //WIB2FrameHandler m_wib2_frame_handler_second_half;
-
-  // Pattern generator configs
-  WIB2PatternGenerator m_wib2_pattern_generator;
-  std::vector<int> m_random_channels; 
-  int m_pattern_index = 0;
 
   //std::thread m_add_hits_tphandler_thread;
 

--- a/include/fdreadoutlibs/wibeth/WIBEthFrameProcessor.hpp
+++ b/include/fdreadoutlibs/wibeth/WIBEthFrameProcessor.hpp
@@ -42,31 +42,6 @@
 namespace dunedaq {
 namespace fdreadoutlibs {
 
-// Pattern generator class for creating different types of TP patterns
-// AAA: at the moment the pattern generator is very simple: random source id and random channel
-class WIBEthPatternGenerator {
-
-public:
-  WIBEthPatternGenerator() {
-    m_size = 1000000;
-  };
-  ~WIBEthPatternGenerator() {};
-
-  void generate(int);
-
-  std::vector<int> get_channels() {
-    return m_channel;
-  }
-
-  int get_total_size() {
-    return m_size;
-  }
- 
-private: 
-  int m_size;
-  std::vector<int> m_channel;
-};
-
 class WIBEthFrameHandler {
 
 public: 
@@ -126,17 +101,9 @@ protected:
   dunedaq::daqdataformats::timestamp_t m_previous_ts = 0;
   dunedaq::daqdataformats::timestamp_t m_current_ts = 0;
 
-  dunedaq::daqdataformats::timestamp_t m_pattern_generator_previous_ts = 0;
-  dunedaq::daqdataformats::timestamp_t m_pattern_generator_current_ts = 0;
-
   bool m_first_ts_missmatch = true;
   bool m_problem_reported = false;
   std::atomic<int> m_ts_error_ctr{ 0 };
-
-  /**
-   * Pipeline Stage 0: Pattern generator for hit finding in emulated mode
-   * */
-  void use_pattern_generator(frameptr fp);
 
   /**
    * Pipeline Stage 1.: Check proper timestamp increments in WIB frame
@@ -185,11 +152,6 @@ private:
   std::shared_ptr<iomanager::SenderConcept<fdreadoutlibs::types::TriggerPrimitiveTypeAdapter>> m_tp_sink;
   std::shared_ptr<iomanager::SenderConcept<fddetdataformats::WIBEthFrame>> m_err_frame_sink;
   std::unique_ptr<WIBEthFrameHandler> m_wibeth_frame_handler = std::make_unique<WIBEthFrameHandler>();
-
-  // Pattern generator configs
-  WIBEthPatternGenerator m_wibeth_pattern_generator;
-  std::vector<int> m_random_channels; 
-  int m_pattern_index = 0;
 
   //std::thread m_add_hits_tphandler_thread;
 

--- a/src/wib2/WIB2FrameProcessor.cpp
+++ b/src/wib2/WIB2FrameProcessor.cpp
@@ -53,17 +53,6 @@ DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::TriggerPrimitiveTypeAdapter, 
 namespace dunedaq {
 namespace fdreadoutlibs {
 
-void
-WIB2PatternGenerator::generate(int source_id)
-{
-  //TLOG() << "Generate random ADC patterns" ;
-  std::srand(source_id*12345678);
-  m_channel.reserve(m_size);
-  for (int i = 0; i < m_size; i++) {
-      int random_ch = std::rand()%256;
-      m_channel.push_back(random_ch);
-  }
-}
 
 WIB2FrameHandler::WIB2FrameHandler(int register_selector_params)
   : m_register_selector(register_selector_params)
@@ -229,12 +218,6 @@ WIB2FrameProcessor::conf(const nlohmann::json& cfg)
   inherited::add_preprocess_task(std::bind(&WIB2FrameProcessor::timestamp_check, this, std::placeholders::_1));
   if (config.enable_tpg) {
     m_tpg_enabled = true;
-    if (config.emulator_mode) {
-      m_wib2_pattern_generator.generate(m_sourceid.id);
-      m_random_channels = m_wib2_pattern_generator.get_channels();
-      //inherited::add_preprocess_task(std::bind(&WIB2FrameProcessor::use_pattern_generator, this, std::placeholders::_1));
-    }
-
     m_channel_map = dunedaq::detchannelmaps::make_map(config.channel_map_name);
 
     inherited::add_postprocess_task(std::bind(&WIB2FrameProcessor::find_hits, this, std::placeholders::_1, m_wib2_frame_handler.get()));

--- a/src/wib2/WIB2FrameProcessor.cpp
+++ b/src/wib2/WIB2FrameProcessor.cpp
@@ -232,7 +232,7 @@ WIB2FrameProcessor::conf(const nlohmann::json& cfg)
     if (config.emulator_mode) {
       m_wib2_pattern_generator.generate(m_sourceid.id);
       m_random_channels = m_wib2_pattern_generator.get_channels();
-      inherited::add_preprocess_task(std::bind(&WIB2FrameProcessor::use_pattern_generator, this, std::placeholders::_1));
+      //inherited::add_preprocess_task(std::bind(&WIB2FrameProcessor::use_pattern_generator, this, std::placeholders::_1));
     }
 
     m_channel_map = dunedaq::detchannelmaps::make_map(config.channel_map_name);
@@ -295,38 +295,6 @@ WIB2FrameProcessor::get_info(opmonlib::InfoCollector& ci, int level)
   ci.add(info);
 }
 
-/**
- * Add hits using the pattern generator only when in emulated mode
- * */
-void
-WIB2FrameProcessor::use_pattern_generator(frameptr fp)
-{
-
-  // If we are not in the first superchunk then we start applying the pattern generator
-  // This is because we use the ADC values of the first wib frame as the pedestal baseline
-  if (m_current_ts != 0) {
-    auto wfptr = reinterpret_cast<dunedaq::fddetdataformats::WIB2Frame*>((uint8_t*)fp);
-
-    m_pattern_generator_current_ts = wfptr->get_timestamp();
-
-    // Adding a hit every 2442 gives a total Sent TP rate of approx 100 Hz/wire
-    if (m_pattern_generator_current_ts - m_pattern_generator_previous_ts > 2442) {
-
-      // Reset the pattern from the beginning if it reaches the maximum
-      m_pattern_index++;
-      if (m_pattern_index == m_wib2_pattern_generator.get_total_size()) {
-        m_pattern_index = 0;
-      }
-
-      // Set the ADC to the uint16 maximum value
-     
-      wfptr->set_adc(m_random_channels[m_pattern_index], 16383);
-      //TLOG() << "Lift channel " << m_random_channels[m_pattern_index] << " to " << wfptr->get_adc(m_random_channels[m_pattern_index]);
-      // Update the previous timestamp of the pattern generator
-      m_pattern_generator_previous_ts = m_pattern_generator_current_ts;
-    } // timestamp difference
-  } // if not first superchunk
-}
 
 /**
  * Pipeline Stage 1.: Check proper timestamp increments in WIB frame

--- a/src/wibeth/WIBEthFrameProcessor.cpp
+++ b/src/wibeth/WIBEthFrameProcessor.cpp
@@ -230,7 +230,7 @@ WIBEthFrameProcessor::conf(const nlohmann::json& cfg)
     if (config.emulator_mode) {
       m_wibeth_pattern_generator.generate(m_sourceid.id);
       m_random_channels = m_wibeth_pattern_generator.get_channels();
-      inherited::add_preprocess_task(std::bind(&WIBEthFrameProcessor::use_pattern_generator, this, std::placeholders::_1));
+      //inherited::add_preprocess_task(std::bind(&WIBEthFrameProcessor::use_pattern_generator, this, std::placeholders::_1));
     }
 
     m_channel_map = dunedaq::detchannelmaps::make_map(config.channel_map_name);

--- a/src/wibeth/tpg/RegisterToChannelNumber.cpp
+++ b/src/wibeth/tpg/RegisterToChannelNumber.cpp
@@ -108,7 +108,7 @@ get_register_to_offline_channel_map_wibeth(const dunedaq::fddetdataformats::WIBE
     int16_t out_val = register_array.uint16(index);
     ret.channel[i] = out_val + min_ch;
 
-    std::cout << " index: " << index << "    value:   " << out_val << std::endl;
+    //std::cout << " index: " << index << "    value:   " << out_val << std::endl;
 
 
 


### PR DESCRIPTION
Removed ADC generation from FrameProcessors (pre-processing task) and added instead the ADC pattern generator in the SourceEmulatorModel. 

A new DAQConf entry has been added for enabling the ADC pattern generation.

This fixes issues #110 and #124 

