### PR TITLE
Watching for late-arriving TPs in tp_datalinkhandler modules

### DIFF
--- a/include/fdreadoutlibs/FDReadoutIssues.hpp
+++ b/include/fdreadoutlibs/FDReadoutIssues.hpp
@@ -35,9 +35,9 @@ ERS_DECLARE_ISSUE(fdreadoutlibs,
 		          ((uint64_t)width) ((uint64_t)channel))
 
 ERS_DECLARE_ISSUE(fdreadoutlibs,
-                  TPDropped,
-                  "TP with ToT " << width << " for channel " << channel,
-                  ((uint64_t)width) ((uint64_t)channel))
+                  FailedToSendTP,
+                  "Failed to send TP with start time " << s_ts << " and channel number " << channel,
+                  ((dunedaq::daqdataformats::timestamp_t)s_ts) ((uint64_t)channel))
 
 
 ERS_DECLARE_ISSUE(fdreadoutlibs,

--- a/include/fdreadoutlibs/TPCTPRequestHandler.hpp
+++ b/include/fdreadoutlibs/TPCTPRequestHandler.hpp
@@ -84,7 +84,7 @@ private:
 
   std::atomic<uint64_t> m_new_tps{ 0 }; // NOLINT(build/unsigned)
   std::atomic<uint64_t> m_new_tpsets{ 0 };  // NOLINT(build/unsigned)
-  std::atomic<uint64_t> m_new_tps_send_failed{ 0 };
+  std::atomic<uint64_t> m_new_tps_in_tpsets_send_failed{ 0 };
   std::atomic<uint64_t> m_new_tpsets_send_failed{ 0 };
   std::atomic<uint64_t> m_new_tps_suppressed_tardy{ 0 };
   std::atomic<uint64_t> m_new_heartbeats{ 0 };

--- a/include/fdreadoutlibs/TPCTPRequestHandler.hpp
+++ b/include/fdreadoutlibs/TPCTPRequestHandler.hpp
@@ -69,7 +69,7 @@ public:
 
   timestamp_t get_cutoff_timestamp() override {return m_cutoff_timestamp.load();}
   bool supports_cutoff_timestamp() override {return true;}
-  void increment_missed_tp_count() override {++m_new_tps_missed;}
+  void increment_tardy_tp_count() override {++m_new_tps_suppressed_tardy;}
 
 protected:
   
@@ -84,9 +84,9 @@ private:
 
   std::atomic<uint64_t> m_new_tps{ 0 }; // NOLINT(build/unsigned)
   std::atomic<uint64_t> m_new_tpsets{ 0 };  // NOLINT(build/unsigned)
-  std::atomic<uint64_t> m_new_tps_lost{ 0 };
-  std::atomic<uint64_t> m_new_tpsets_lost{ 0 };
-  std::atomic<uint64_t> m_new_tps_missed{ 0 };
+  std::atomic<uint64_t> m_new_tps_send_failed{ 0 };
+  std::atomic<uint64_t> m_new_tpsets_send_failed{ 0 };
+  std::atomic<uint64_t> m_new_tps_suppressed_tardy{ 0 };
   std::atomic<uint64_t> m_new_heartbeats{ 0 };
 
   std::atomic<timestamp_t> m_cutoff_timestamp{ 0 }; // NOLINT(build/unsigned)

--- a/include/fdreadoutlibs/TPCTPRequestHandler.hpp
+++ b/include/fdreadoutlibs/TPCTPRequestHandler.hpp
@@ -9,17 +9,17 @@
 #ifndef FDREADOUTLIBS_INCLUDE_FDREADOUTLIBS_WIB2_TPCTPREQUESTHANDLER_HPP_
 #define FDREADOUTLIBS_INCLUDE_FDREADOUTLIBS_WIB2_TPCTPREQUESTHANDLER_HPP_
 
+#include "fdreadoutlibs/TriggerPrimitiveTypeAdapter.hpp"
+
+#include "daqdataformats/Types.hpp"
 #include "iomanager/IOManager.hpp"
 #include "iomanager/Sender.hpp"
-
 #include "readoutlibs/ReadoutLogging.hpp"
 #include "readoutlibs/utils/ReusableThread.hpp"
 #include "readoutlibs/FrameErrorRegistry.hpp"
 #include "readoutlibs/ReadoutIssues.hpp"
 #include "readoutlibs/ReadoutLogging.hpp"
 #include "readoutlibs/models/DefaultSkipListRequestHandler.hpp"
-
-#include "fdreadoutlibs/TriggerPrimitiveTypeAdapter.hpp"
 #include "trigger/TPSet.hpp"
  
 #include <atomic>
@@ -31,10 +31,11 @@ using dunedaq::readoutlibs::logging::TLVL_WORK_STEPS;
 
 namespace dunedaq {
 ERS_DECLARE_ISSUE(fdreadoutlibs,
-                  DroppedTPSet,
-                  "Failed to send TPs from  " << s_ts << " to " << e_ts,
-                  ((uint64_t)s_ts) 
-		  ((uint64_t)e_ts))
+                  FailedToSendTPSet,
+                  "Failed to send TPs from start time " << s_ts << " to end time " << e_ts << " in run " << run,
+                  ((dunedaq::daqdataformats::timestamp_t)s_ts) 
+                  ((dunedaq::daqdataformats::timestamp_t)e_ts)
+                  ((dunedaq::daqdataformats::run_number_t)run))
 ERS_DECLARE_ISSUE(fdreadoutlibs,
                    TPHandlerMsg,
                    infomsg,
@@ -47,7 +48,7 @@ class TPCTPRequestHandler : public dunedaq::readoutlibs::DefaultSkipListRequestH
 {
 public:
   using inherited2 = readoutlibs::DefaultSkipListRequestHandler<types::TriggerPrimitiveTypeAdapter>;
-  using timestamp_t = std::uint64_t;
+  using timestamp_t = dunedaq::daqdataformats::timestamp_t;
 
   // Constructor that binds LB and error registry
 
@@ -66,22 +67,29 @@ public:
   void stop(const nlohmann::json& args) override;
   void get_info(opmonlib::InfoCollector& ci, int level) override;
 
+  timestamp_t get_cutoff_timestamp() override {return m_cutoff_timestamp.load();}
+  bool supports_cutoff_timestamp() override {return true;}
+  void increment_missed_tp_count() override {++m_new_tps_missed;}
+
 protected:
   
 private:
   std::shared_ptr<iomanager::SenderConcept<dunedaq::trigger::TPSet>> m_tpset_sink;
   int m_tp_set_sender_sleep_us;
   uint64_t m_ts_set_sender_offset_ticks;
-  uint64_t m_run_number;
+  dunedaq::daqdataformats::run_number_t m_run_number;
   dunedaq::readoutlibs::ReusableThread  m_tp_set_sender_thread;
   void send_tp_sets();
   uint64_t m_next_tpset_seqno;
 
   std::atomic<uint64_t> m_new_tps{ 0 }; // NOLINT(build/unsigned)
   std::atomic<uint64_t> m_new_tpsets{ 0 };  // NOLINT(build/unsigned)
-  std::atomic<uint64_t> m_new_tps_dropped{ 0 };
+  std::atomic<uint64_t> m_new_tps_lost{ 0 };
+  std::atomic<uint64_t> m_new_tpsets_lost{ 0 };
+  std::atomic<uint64_t> m_new_tps_missed{ 0 };
   std::atomic<uint64_t> m_new_heartbeats{ 0 };
 
+  std::atomic<timestamp_t> m_cutoff_timestamp{ 0 }; // NOLINT(build/unsigned)
 };
 
 } // namespace readoutlibs

--- a/include/fdreadoutlibs/wib/WIBFrameProcessor.hpp
+++ b/include/fdreadoutlibs/wib/WIBFrameProcessor.hpp
@@ -115,7 +115,7 @@ public:
       m_tphandler->set_run_number(start_params.run);
   
       m_tphandler->reset();
-      m_tps_dropped = 0;
+      m_tps_suppressed_too_long = 0;
 
       m_coll_taps = swtpg::firwin_int(7, 0.1, m_coll_multiplier);
       m_coll_taps.push_back(0);
@@ -300,7 +300,7 @@ public:
     if (m_tphandler != nullptr) {
       info.num_tps_sent = m_tphandler->get_and_reset_num_sent_tps();
       info.num_tpsets_sent = m_tphandler->get_and_reset_num_sent_tpsets();
-      info.num_tps_dropped = m_tps_dropped.exchange(0);
+      info.num_tps_suppressed_too_long = m_tps_suppressed_too_long.exchange(0);
     }
     info.num_frame_errors = m_frame_error_count.exchange(0);
 
@@ -663,7 +663,7 @@ protected:
           }
 
           if (!m_tphandler->add_tp(trigprim, timestamp)) {
-            m_tps_dropped++;
+            m_tps_suppressed_too_long++;
           }
 
           m_new_tps++;
@@ -751,7 +751,7 @@ private:
 
   std::atomic<uint64_t> m_new_hits{ 0 }; // NOLINT(build/unsigned)
   std::atomic<uint64_t> m_new_tps{ 0 };  // NOLINT(build/unsigned)
-  std::atomic<uint64_t> m_tps_dropped{ 0 };
+  std::atomic<uint64_t> m_tps_suppressed_too_long{ 0 };
 
   std::chrono::time_point<std::chrono::high_resolution_clock> m_t0;
 };

--- a/include/fdreadoutlibs/wib2/WIB2FrameProcessor.hpp
+++ b/include/fdreadoutlibs/wib2/WIB2FrameProcessor.hpp
@@ -166,6 +166,7 @@ private:
   std::atomic<uint64_t> m_new_hits{ 0 }; // NOLINT(build/unsigned)
   std::atomic<uint64_t> m_new_tps{ 0 };  // NOLINT(build/unsigned)
   std::atomic<uint64_t> m_tps_dropped{ 0 };
+  std::atomic<uint64_t> m_tps_lost{ 0 };
 
   std::chrono::time_point<std::chrono::high_resolution_clock> m_t0;
 };

--- a/include/fdreadoutlibs/wib2/WIB2FrameProcessor.hpp
+++ b/include/fdreadoutlibs/wib2/WIB2FrameProcessor.hpp
@@ -165,8 +165,8 @@ private:
 
   std::atomic<uint64_t> m_new_hits{ 0 }; // NOLINT(build/unsigned)
   std::atomic<uint64_t> m_new_tps{ 0 };  // NOLINT(build/unsigned)
-  std::atomic<uint64_t> m_tps_dropped{ 0 };
-  std::atomic<uint64_t> m_tps_lost{ 0 };
+  std::atomic<uint64_t> m_tps_suppressed_too_long{ 0 };
+  std::atomic<uint64_t> m_tps_send_failed{ 0 };
 
   std::chrono::time_point<std::chrono::high_resolution_clock> m_t0;
 };

--- a/include/fdreadoutlibs/wibeth/WIBEthFrameProcessor.hpp
+++ b/include/fdreadoutlibs/wibeth/WIBEthFrameProcessor.hpp
@@ -181,8 +181,8 @@ private:
 
   std::atomic<uint64_t> m_new_hits{ 0 }; // NOLINT(build/unsigned)
   std::atomic<uint64_t> m_new_tps{ 0 };  // NOLINT(build/unsigned)
-  std::atomic<uint64_t> m_tps_dropped{ 0 };
-  std::atomic<uint64_t> m_tps_lost{ 0 };
+  std::atomic<uint64_t> m_tps_suppressed_too_long{ 0 };
+  std::atomic<uint64_t> m_tps_send_failed{ 0 };
 
   std::chrono::time_point<std::chrono::high_resolution_clock> m_t0;
 };

--- a/include/fdreadoutlibs/wibeth/WIBEthFrameProcessor.hpp
+++ b/include/fdreadoutlibs/wibeth/WIBEthFrameProcessor.hpp
@@ -182,6 +182,7 @@ private:
   std::atomic<uint64_t> m_new_hits{ 0 }; // NOLINT(build/unsigned)
   std::atomic<uint64_t> m_new_tps{ 0 };  // NOLINT(build/unsigned)
   std::atomic<uint64_t> m_tps_dropped{ 0 };
+  std::atomic<uint64_t> m_tps_lost{ 0 };
 
   std::chrono::time_point<std::chrono::high_resolution_clock> m_t0;
 };

--- a/src/TPCTPRequestHandler.cpp
+++ b/src/TPCTPRequestHandler.cpp
@@ -30,12 +30,15 @@ void
 TPCTPRequestHandler::start(const nlohmann::json& args) {
    m_new_tps = 0;
    m_new_tpsets = 0;
-   m_new_tps_dropped = 0;
+   m_new_tps_lost = 0;
+   m_new_tpsets_lost = 0;
+   m_new_tps_missed = 0;
    inherited2::start(args);
 
    rcif::cmd::StartParams start_params = args.get<rcif::cmd::StartParams>();
    m_run_number = start_params.run;
 
+   m_cutoff_timestamp.store(0);
    m_tp_set_sender_thread.set_work(&TPCTPRequestHandler::send_tp_sets, this);
 }
 
@@ -46,7 +49,7 @@ TPCTPRequestHandler::stop(const nlohmann::json& args) {
           std::this_thread::sleep_for(std::chrono::milliseconds(10));
 	}
 	inherited2::stop(args);
-
+	m_cutoff_timestamp.store(0);
 }
 
 void
@@ -57,7 +60,9 @@ TPCTPRequestHandler::get_info(opmonlib::InfoCollector& ci, int level)
   auto now = std::chrono::high_resolution_clock::now();
   int new_tps = m_new_tps.exchange(0);
   int new_tpsets = m_new_tpsets.exchange(0);
-  int new_tps_dropped = m_new_tps_dropped.exchange(0);
+  int new_tps_lost = m_new_tps_lost.exchange(0);
+  int new_tpsets_lost = m_new_tpsets_lost.exchange(0);
+  int new_tps_missed = m_new_tps_missed.exchange(0);
   int new_heartbeats = m_new_heartbeats.exchange(0);
   //double seconds = std::chrono::duration_cast<std::chrono::microseconds>(now - m_t0).count() / 1000000.;
   //TLOG() << "TPSets rate: " << std::to_string(new_tpsets / seconds) << " [Hz], TP rate: " << std::to_string(new_tps / seconds) << ", heartbeats: " << std::to_string(new_heartbeats / seconds) << " [Hz]";
@@ -65,7 +70,9 @@ TPCTPRequestHandler::get_info(opmonlib::InfoCollector& ci, int level)
  
   info.num_tps_sent = new_tps;
   info.num_tpsets_sent = new_tpsets;
-  info.num_tps_dropped = new_tps_dropped;
+  info.num_tps_lost = new_tps_lost;
+  info.num_tpsets_lost = new_tpsets_lost;
+  info.num_tps_missed = new_tps_missed;
   info.num_heartbeats = new_heartbeats;
   m_t0 = now;
   inherited2::get_info(ci, level);
@@ -139,16 +146,20 @@ TPCTPRequestHandler::send_tp_sets() {
 	       tpset.end_time = tp.time_start;
 	       tpset.objects.emplace_back(std::move(tp)); 
             }
-	 } 
-         if(!m_tpset_sink->try_send(std::move(tpset), iomanager::Sender::s_no_block)) {
-	    ers::warning(DroppedTPSet(ERS_HERE, start_win_ts, end_win_ts));
-	    m_new_tps_dropped += num_tps;
          }
-         m_new_tps += num_tps;
-         m_new_tpsets++;
+         m_cutoff_timestamp.store(tpset.end_time);
+         if(!m_tpset_sink->try_send(std::move(tpset), iomanager::Sender::s_no_block)) {
+           ers::warning(FailedToSendTPSet(ERS_HERE, start_win_ts, end_win_ts, m_run_number));
+           m_new_tps_lost += num_tps;
+           ++m_new_tpsets_lost;
+         }
+         else {
+           m_new_tps += num_tps;
+           ++m_new_tpsets;
+         }
 
 	 if (num_tps == 0) {
-		 m_new_heartbeats++;
+           m_new_heartbeats++;
 	 }
          //remember what we sent for the next loop
          start_win_ts = end_win_ts;

--- a/src/TPCTPRequestHandler.cpp
+++ b/src/TPCTPRequestHandler.cpp
@@ -30,7 +30,7 @@ void
 TPCTPRequestHandler::start(const nlohmann::json& args) {
    m_new_tps = 0;
    m_new_tpsets = 0;
-   m_new_tps_send_failed = 0;
+   m_new_tps_in_tpsets_send_failed = 0;
    m_new_tpsets_send_failed = 0;
    m_new_tps_suppressed_tardy = 0;
    inherited2::start(args);
@@ -60,7 +60,7 @@ TPCTPRequestHandler::get_info(opmonlib::InfoCollector& ci, int level)
   auto now = std::chrono::high_resolution_clock::now();
   int new_tps = m_new_tps.exchange(0);
   int new_tpsets = m_new_tpsets.exchange(0);
-  int new_tps_send_failed = m_new_tps_send_failed.exchange(0);
+  int new_tps_in_tpsets_send_failed = m_new_tps_in_tpsets_send_failed.exchange(0);
   int new_tpsets_send_failed = m_new_tpsets_send_failed.exchange(0);
   int new_tps_suppressed_tardy = m_new_tps_suppressed_tardy.exchange(0);
   int new_heartbeats = m_new_heartbeats.exchange(0);
@@ -70,7 +70,7 @@ TPCTPRequestHandler::get_info(opmonlib::InfoCollector& ci, int level)
  
   info.num_tps_sent = new_tps;
   info.num_tpsets_sent = new_tpsets;
-  info.num_tps_send_failed = new_tps_send_failed;
+  info.num_tps_in_tpsets_send_failed = new_tps_in_tpsets_send_failed;
   info.num_tpsets_send_failed = new_tpsets_send_failed;
   info.num_tps_suppressed_tardy = new_tps_suppressed_tardy;
   info.num_heartbeats = new_heartbeats;
@@ -150,7 +150,7 @@ TPCTPRequestHandler::send_tp_sets() {
          m_cutoff_timestamp.store(tpset.end_time);
          if(!m_tpset_sink->try_send(std::move(tpset), iomanager::Sender::s_no_block)) {
            ers::warning(FailedToSendTPSet(ERS_HERE, start_win_ts, end_win_ts, m_run_number));
-           m_new_tps_send_failed += num_tps;
+           m_new_tps_in_tpsets_send_failed += num_tps;
            ++m_new_tpsets_send_failed;
          }
          else {

--- a/src/wib2/WIB2FrameProcessor.cpp
+++ b/src/wib2/WIB2FrameProcessor.cpp
@@ -144,8 +144,8 @@ WIB2FrameProcessor::start(const nlohmann::json& args)
 {
   // Reset software TPG resources
   if (m_tpg_enabled) {
-    m_tps_dropped = 0;
-    m_tps_lost = 0;
+    m_tps_suppressed_too_long = 0;
+    m_tps_send_failed = 0;
 
     m_wib2_frame_handler->initialize(m_tpg_threshold_selected);
     m_wib2_frame_handler_second_half->initialize(m_tpg_threshold_selected);
@@ -237,17 +237,17 @@ WIB2FrameProcessor::get_info(opmonlib::InfoCollector& ci, int level)
   if (m_tpg_enabled) {
     int new_hits = m_tpg_hits_count.exchange(0);
     int new_tps = m_new_tps.exchange(0);
-    int new_dropped_tps = m_tps_dropped.exchange(0);
-    int new_lost_tps = m_tps_lost.exchange(0);
+    int new_tps_suppressed_too_long = m_tps_suppressed_too_long.exchange(0);
+    int new_tps_send_failed = m_tps_send_failed.exchange(0);
     double seconds = std::chrono::duration_cast<std::chrono::microseconds>(now - m_t0).count() / 1000000.;
     TLOG_DEBUG(TLVL_BOOKKEEPING) << "Hit rate: " << std::to_string(new_hits / seconds / 1000.) << " [kHz]";
-    TLOG() << " Hit rate: " << std::to_string(new_hits / seconds / 1000.) << " [kHz], dropped rate: " << std::to_string(new_dropped_tps / seconds / 1000.) << " [kHz]";;
+    TLOG() << " Hit rate: " << std::to_string(new_hits / seconds / 1000.) << " [kHz], dropped rate: " << std::to_string(new_tps_suppressed_too_long / seconds / 1000.) << " [kHz]";;
     TLOG_DEBUG(TLVL_BOOKKEEPING) << "Total new hits: " << new_hits << " new TPs: " << new_tps;
     info.rate_tp_hits = new_hits / seconds / 1000.;
 
     info.num_tps_sent = new_tps;
-    info.num_tps_dropped = new_dropped_tps;
-    info.num_tps_lost = new_lost_tps;
+    info.num_tps_suppressed_too_long = new_tps_suppressed_too_long;
+    info.num_tps_send_failed = new_tps_send_failed;
     // Find the channels with the top  TP rates
     // Create a vector of pairs to store the map elements
     std::vector<std::pair<uint, int>> channel_tp_rate_vec(m_tp_channel_rate_map.begin(), m_tp_channel_rate_map.end());
@@ -458,12 +458,12 @@ WIB2FrameProcessor::process_swtpg_hits(uint16_t* primfind_it, dunedaq::daqdatafo
           tp.tp.version = 1;
           if(tp.tp.time_over_threshold > m_tp_max_width) {
 		  ers::warning(TPTooLong(ERS_HERE, tp.tp.time_over_threshold, tp.tp.channel));
-		  m_tps_dropped++;
+		  m_tps_suppressed_too_long++;
 	  }
 	  //Send the TP to the TP handler module
 	  else if(!m_tp_sink->try_send(std::move(tp), iomanager::Sender::s_no_block)) {
 		 ers::warning(FailedToSendTP(ERS_HERE, tp.tp.time_start, tp.tp.channel));
-		 m_tps_lost++;
+		 m_tps_send_failed++;
 	  }	 
           m_new_tps++;
           ++nhits;

--- a/src/wib2/WIB2FrameProcessor.cpp
+++ b/src/wib2/WIB2FrameProcessor.cpp
@@ -145,6 +145,7 @@ WIB2FrameProcessor::start(const nlohmann::json& args)
   // Reset software TPG resources
   if (m_tpg_enabled) {
     m_tps_dropped = 0;
+    m_tps_lost = 0;
 
     m_wib2_frame_handler->initialize(m_tpg_threshold_selected);
     m_wib2_frame_handler_second_half->initialize(m_tpg_threshold_selected);
@@ -237,6 +238,7 @@ WIB2FrameProcessor::get_info(opmonlib::InfoCollector& ci, int level)
     int new_hits = m_tpg_hits_count.exchange(0);
     int new_tps = m_new_tps.exchange(0);
     int new_dropped_tps = m_tps_dropped.exchange(0);
+    int new_lost_tps = m_tps_lost.exchange(0);
     double seconds = std::chrono::duration_cast<std::chrono::microseconds>(now - m_t0).count() / 1000000.;
     TLOG_DEBUG(TLVL_BOOKKEEPING) << "Hit rate: " << std::to_string(new_hits / seconds / 1000.) << " [kHz]";
     TLOG() << " Hit rate: " << std::to_string(new_hits / seconds / 1000.) << " [kHz], dropped rate: " << std::to_string(new_dropped_tps / seconds / 1000.) << " [kHz]";;
@@ -245,6 +247,7 @@ WIB2FrameProcessor::get_info(opmonlib::InfoCollector& ci, int level)
 
     info.num_tps_sent = new_tps;
     info.num_tps_dropped = new_dropped_tps;
+    info.num_tps_lost = new_lost_tps;
     // Find the channels with the top  TP rates
     // Create a vector of pairs to store the map elements
     std::vector<std::pair<uint, int>> channel_tp_rate_vec(m_tp_channel_rate_map.begin(), m_tp_channel_rate_map.end());
@@ -459,8 +462,8 @@ WIB2FrameProcessor::process_swtpg_hits(uint16_t* primfind_it, dunedaq::daqdatafo
 	  }
 	  //Send the TP to the TP handler module
 	  else if(!m_tp_sink->try_send(std::move(tp), iomanager::Sender::s_no_block)) {
-		 ers::warning(TPDropped(ERS_HERE, tp.tp.time_start, tp.tp.channel));
-		 m_tps_dropped++;
+		 ers::warning(FailedToSendTP(ERS_HERE, tp.tp.time_start, tp.tp.channel));
+		 m_tps_lost++;
 	  }	 
           m_new_tps++;
           ++nhits;

--- a/src/wibeth/WIBEthFrameProcessor.cpp
+++ b/src/wibeth/WIBEthFrameProcessor.cpp
@@ -136,8 +136,8 @@ WIBEthFrameProcessor::start(const nlohmann::json& args)
 {
   // Reset software TPG resources
   if (m_tpg_enabled) {
-    m_tps_dropped = 0;
-    m_tps_lost = 0;
+    m_tps_suppressed_too_long = 0;
+    m_tps_send_failed = 0;
 
     m_wibeth_frame_handler->initialize(m_tpg_threshold_selected);
   } // end if(m_tpg_enabled)
@@ -247,17 +247,17 @@ WIBEthFrameProcessor::get_info(opmonlib::InfoCollector& ci, int level)
   if (m_tpg_enabled) {
     int new_hits = m_tpg_hits_count.exchange(0);
     int new_tps = m_new_tps.exchange(0);
-    int new_dropped_tps = m_tps_dropped.exchange(0);
-    int new_lost_tps = m_tps_lost.exchange(0);
+    int new_tps_suppressed_too_long = m_tps_suppressed_too_long.exchange(0);
+    int new_tps_send_failed = m_tps_send_failed.exchange(0);
     double seconds = std::chrono::duration_cast<std::chrono::microseconds>(now - m_t0).count() / 1000000.;
     TLOG_DEBUG(TLVL_BOOKKEEPING) << "Hit rate: " << std::to_string(new_hits / seconds / 1000.) << " [kHz]";
-    //TLOG() << " Hit rate: " << std::to_string(new_hits / seconds / 1000.) << " [kHz], dropped rate: " << std::to_string(new_dropped_tps / seconds / 1000.) << " [kHz]";;
+    //TLOG() << " Hit rate: " << std::to_string(new_hits / seconds / 1000.) << " [kHz], dropped rate: " << std::to_string(new_tps_suppressed_too_long / seconds / 1000.) << " [kHz]";;
     TLOG_DEBUG(TLVL_BOOKKEEPING) << "Total new hits: " << new_hits << " new TPs: " << new_tps;
     info.rate_tp_hits = new_hits / seconds / 1000.;
 
     info.num_tps_sent = new_tps;
-    info.num_tps_dropped = new_dropped_tps;
-    info.num_tps_lost = new_lost_tps;
+    info.num_tps_suppressed_too_long = new_tps_suppressed_too_long;
+    info.num_tps_send_failed = new_tps_send_failed;
     // Find the channels with the top  TP rates
     // Create a vector of pairs to store the map elements
     std::vector<std::pair<uint, int>> channel_tp_rate_vec(m_tp_channel_rate_map.begin(), m_tp_channel_rate_map.end());
@@ -526,12 +526,12 @@ WIBEthFrameProcessor::process_swtpg_hits(uint16_t* primfind_it, dunedaq::daqdata
           tp.tp.version = 1;
           if(tp.tp.time_over_threshold > m_tp_max_width) {
             ers::warning(TPTooLong(ERS_HERE, tp.tp.time_over_threshold, tp.tp.channel));
-            m_tps_dropped++;
+            m_tps_suppressed_too_long++;
 	  }
 	  //Send the TP to the TP handler module
 	  else if(!m_tp_sink->try_send(std::move(tp), iomanager::Sender::s_no_block)) {
             ers::warning(FailedToSendTP(ERS_HERE, tp.tp.time_start, tp.tp.channel));
-            m_tps_lost++;
+            m_tps_send_failed++;
 	  }
           else {
             m_new_tps++;


### PR DESCRIPTION
These changes, along with ones in the `readoutlibs` repo ([PR 147](https://github.com/DUNE-DAQ/readoutlibs/pull/147)), were added to help users be informed about situations in which TriggerPrimitives arrive at `tp_datalinkhandler` module instances too late to be sent downstream to the Trigger in TPSets.  

This late-arrival behavior was noticed in automated integration tests.  More details are available in [these slides](https://indico.fnal.gov/event/62384/contributions/280702/attachments/173317/234594/OccasionalMissingTPs_05Dec2023_KAB.pdf) from the [06-Dec-2023 Core Software meeting](https://indico.fnal.gov/event/62384/).   

The TP-arrival-time-monitoring code that is included in these changes does not implement the idea presented in those slides, but rather is based on a suggestion by Wes (and others?) at the meeting.  That suggestion was to monitor the timestamps of TPs as they are added to the Latency Buffer, instead of periodically looking through the LB for missed TPs after they are added.  

These changes have been verified to report warnings when the number of TP-based triggers fluctuates lower in integtests.

As part of these changes, new operational monitoring metrics have been added, and an existing metric has been renamed to better reflect the actual quantity that is being monitored.

It would be appreciated if reviewers would provide feedback on the implementation details of the 'watch TPs as they are added to the LB' model, in addition to all other aspects of the changes.  Care was taken to try to avoid CPU intensive changes.

As discussed at the Core SW meeting, we should investigate other ways to handle late-arriving TPs at the tp_datalinkhandler, and I will file an Issue for that.