### PR TITLE
Improved the Tardy-TP warning message and added suppression of it at start-run

### DIFF
--- a/include/fdreadoutlibs/TPCTPRequestHandler.hpp
+++ b/include/fdreadoutlibs/TPCTPRequestHandler.hpp
@@ -80,8 +80,6 @@ public:
 
   timestamp_t get_cutoff_timestamp() override {return m_cutoff_timestamp.load();}
   bool supports_cutoff_timestamp() override {return true;}
-  timestamp_t get_allowed_latency() override {return m_ts_set_sender_offset_ticks;}
-  void increment_tardy_tp_count() override {++m_new_tps_suppressed_tardy;}
   void report_tardy_packet(const types::TriggerPrimitiveTypeAdapter& packet, int64_t tardy_ticks) override;
 
 protected:

--- a/include/fdreadoutlibs/TPCTPRequestHandler.hpp
+++ b/include/fdreadoutlibs/TPCTPRequestHandler.hpp
@@ -69,6 +69,7 @@ public:
 
   timestamp_t get_cutoff_timestamp() override {return m_cutoff_timestamp.load();}
   bool supports_cutoff_timestamp() override {return true;}
+  timestamp_t get_allowed_latency() override {return m_ts_set_sender_offset_ticks;}
   void increment_tardy_tp_count() override {++m_new_tps_suppressed_tardy;}
 
 protected:

--- a/include/fdreadoutlibs/TPCTPRequestHandler.hpp
+++ b/include/fdreadoutlibs/TPCTPRequestHandler.hpp
@@ -23,6 +23,7 @@
 #include "trigger/TPSet.hpp"
  
 #include <atomic>
+#include <chrono>
 #include <memory>
 #include <string>
 
@@ -40,6 +41,16 @@ ERS_DECLARE_ISSUE(fdreadoutlibs,
                    TPHandlerMsg,
                    infomsg,
                    ((std::string) infomsg))
+
+ERS_DECLARE_ISSUE(fdreadoutlibs,
+                  DataPacketArrivedTooLate,
+                  "SourceID[" << sid_subsystem << "," << sid_id << "] Received late data packet, "
+                  << "TP channel " << tpchan << ", "
+                  << msec_diff << " ms beyond the allowed latency ("
+                  << msec_allowed << " ms, " << ticks_allowed << " ticks).",
+                  ((std::string)sid_subsystem)((daqdataformats::SourceID::ID_t)sid_id)
+                  ((trgdataformats::channel_t)tpchan)((double)msec_diff)
+                  ((double)msec_allowed)((daqdataformats::timestamp_t)ticks_allowed))
 
 namespace fdreadoutlibs {
 
@@ -71,6 +82,7 @@ public:
   bool supports_cutoff_timestamp() override {return true;}
   timestamp_t get_allowed_latency() override {return m_ts_set_sender_offset_ticks;}
   void increment_tardy_tp_count() override {++m_new_tps_suppressed_tardy;}
+  void report_tardy_packet(const types::TriggerPrimitiveTypeAdapter& packet, int64_t tardy_ticks) override;
 
 protected:
   
@@ -78,6 +90,7 @@ private:
   std::shared_ptr<iomanager::SenderConcept<dunedaq::trigger::TPSet>> m_tpset_sink;
   int m_tp_set_sender_sleep_us;
   uint64_t m_ts_set_sender_offset_ticks;
+  int m_tardy_tp_quiet_time_at_start_sec;
   dunedaq::daqdataformats::run_number_t m_run_number;
   dunedaq::readoutlibs::ReusableThread  m_tp_set_sender_thread;
   void send_tp_sets();
@@ -91,6 +104,7 @@ private:
   std::atomic<uint64_t> m_new_heartbeats{ 0 };
 
   std::atomic<timestamp_t> m_cutoff_timestamp{ 0 }; // NOLINT(build/unsigned)
+  std::chrono::time_point<std::chrono::high_resolution_clock> m_run_start_timepoint;
 };
 
 } // namespace readoutlibs

--- a/src/TPCTPRequestHandler.cpp
+++ b/src/TPCTPRequestHandler.cpp
@@ -84,6 +84,7 @@ TPCTPRequestHandler::get_info(opmonlib::InfoCollector& ci, int level)
 void
 TPCTPRequestHandler::report_tardy_packet(const types::TriggerPrimitiveTypeAdapter& packet, int64_t tardy_ticks)
 {
+  ++m_new_tps_suppressed_tardy;
   auto current_time = std::chrono::high_resolution_clock::now();
   if (std::chrono::duration_cast<std::chrono::seconds>(current_time - m_run_start_timepoint).count() >
       m_tardy_tp_quiet_time_at_start_sec) {

--- a/src/TPCTPRequestHandler.cpp
+++ b/src/TPCTPRequestHandler.cpp
@@ -23,6 +23,7 @@ TPCTPRequestHandler::conf(const nlohmann::json& args) {
    inherited2::conf(args);
    m_tp_set_sender_sleep_us = 1000000/conf.tpset_transmission_rate_hz;
    m_ts_set_sender_offset_ticks = conf.tpset_min_latency_ticks;
+   m_tardy_tp_quiet_time_at_start_sec = conf.tardy_tp_quiet_time_at_start_sec;
 }
 
 
@@ -40,6 +41,7 @@ TPCTPRequestHandler::start(const nlohmann::json& args) {
 
    m_cutoff_timestamp.store(0);
    m_tp_set_sender_thread.set_work(&TPCTPRequestHandler::send_tp_sets, this);
+   m_run_start_timepoint = std::chrono::high_resolution_clock::now();
 }
 
 void
@@ -79,6 +81,19 @@ TPCTPRequestHandler::get_info(opmonlib::InfoCollector& ci, int level)
   ci.add(info);
 }
 
+void
+TPCTPRequestHandler::report_tardy_packet(const types::TriggerPrimitiveTypeAdapter& packet, int64_t tardy_ticks)
+{
+  auto current_time = std::chrono::high_resolution_clock::now();
+  if (std::chrono::duration_cast<std::chrono::seconds>(current_time - m_run_start_timepoint).count() >
+      m_tardy_tp_quiet_time_at_start_sec) {
+    ers::warning(DataPacketArrivedTooLate(ERS_HERE, daqdataformats::SourceID::subsystem_to_string(m_sourceid.subsystem),
+                                          m_sourceid.id, packet.tp.channel,
+                                          (static_cast<double>(tardy_ticks)/62500.0),
+                                          (static_cast<double>(m_ts_set_sender_offset_ticks)/62500.0),
+                                          m_ts_set_sender_offset_ticks));
+  }
+}
 
 void
 TPCTPRequestHandler::send_tp_sets() {


### PR DESCRIPTION
Based on various discussions that we have had since the Tardy-TP warnings were first introduced, this PR (along with 3 in other repos) improves the content of the warning message and provides the ability to suppress the warning message at the start of a run, based on a configurable time interval.  The suppression of the warning message does not affect the counting of any Tardy TPs.  Those will still appear in the metrics that are reported.

Here is a sample of the updated warning message:
```
2024-Mar-18 13:00:02,866 WARNING [virtual void dunedaq::fdreadoutlibs::TPCTPRequestHandler::report_tardy_packet(const dunedaq::fdreadoutlibs::types::TriggerPrimitiveTypeAdapter&, int64_t) at /home/nfs/biery/dunedaq/18MarFDDevTardyTPImprovements/sourcecode/fdreadoutlibs/src/TPCTPRequestHandler.cpp:91] SourceID[Trigger,1] Received late data packet, TP channel 1856, 0.16384 ms beyond the allowed latency (20 ms, 1250000 ticks).
```

The default value for the quiet time at the start of the run is 10  seconds.  It can be changed using the `tardy_tp_quiet_time_at_start_sec` parameter in the `readout` section of the `daqconf` configuration inputs.

The changes in other repos that should be included with this one are DUNE-DAQ/readoutlibs#160, DUNE-DAQ/daqconf#434, and DUNE-DAQ/fddaqconf#28.