### PR TITLE
Added TPG RS Factors By Plane

### DIFF
--- a/include/fdreadoutlibs/wibeth/WIBEthFrameProcessor.hpp
+++ b/include/fdreadoutlibs/wibeth/WIBEthFrameProcessor.hpp
@@ -58,7 +58,7 @@ public:
 
   void reset();
 
-  void initialize(uint16_t memory_factor, uint16_t scale_factor, int16_t frug_streaming_acclimt);
+  void initialize(int16_t frug_streaming_acclimt);
  
   uint16_t* get_hits_dest();
 
@@ -146,11 +146,17 @@ protected:
 private:
   bool m_tpg_enabled;
 
-  bool m_enable_simple_threshold_on_plane2 = false;
   // Selected TPG algorithm properties from configuration 
   std::string m_tpg_algorithm;
-  uint16_t m_tpg_rs_memory_factor;
-  uint16_t m_tpg_rs_scale_factor;
+
+  uint16_t m_tpg_rs_memory_factor_plane0;
+  uint16_t m_tpg_rs_memory_factor_plane1;
+  uint16_t m_tpg_rs_memory_factor_plane2;
+
+  uint16_t m_tpg_rs_scale_factor_plane0;
+  uint16_t m_tpg_rs_scale_factor_plane1;
+  uint16_t m_tpg_rs_scale_factor_plane2;
+
   int16_t m_tpg_frugal_streaming_accumulator_limit;
 
 
@@ -192,6 +198,9 @@ private:
   // This is to be used for setting a different value by plane
   // By default set it to 150
   std::array<uint16_t, swtpg_wibeth::NUM_REGISTERS_PER_FRAME * swtpg_wibeth::SAMPLES_PER_REGISTER> m_tpg_threshold = {150};
+
+  // Create an array to store the values of the scale factor.
+  std::array<uint16_t, swtpg_wibeth::NUM_REGISTERS_PER_FRAME * swtpg_wibeth::SAMPLES_PER_REGISTER> m_register_scale_factor = {0};
 
 
   std::function<void(swtpg_wibeth::ProcessingInfo<swtpg_wibeth::NUM_REGISTERS_PER_FRAME>& info)> m_assigned_tpg_algorithm_function;

--- a/include/fdreadoutlibs/wibeth/tpg/ProcessAbsRSAVX2.hpp
+++ b/include/fdreadoutlibs/wibeth/tpg/ProcessAbsRSAVX2.hpp
@@ -26,13 +26,6 @@ process_window_rs_avx2(ProcessingInfo<NREGISTERS>& info)
   const __m256i overflowMax = _mm256_set1_epi16(INT16_MAX);
       
 
-  // Running sum scaling factor
-  //const __m256i R_factor = _mm256_set1_epi16(info.rs_memory_factor);
-
-  // Scaling factor to stop the ADCs from overflowing 
-  // (may not needs this, depends on magnitude of FIR output) 
-  const __m256i scale_factor = _mm256_set1_epi16(info.rs_scale_factor);
-
   // The maximum value that sigma can have before the threshold overflows a 16-bit signed integer
   //const __m256i sigmaMax = _mm256_set1_epi16((1 << 15) / (info.multiplier * info.threshold));
 
@@ -73,6 +66,7 @@ process_window_rs_avx2(ProcessingInfo<NREGISTERS>& info)
     __m256i medianRS = _mm256_lddqu_si256(reinterpret_cast<__m256i*>(state.pedestalsRS) + ireg);     // NOLINT
     __m256i accumRS = _mm256_lddqu_si256(reinterpret_cast<__m256i*>(state.accumRS) + ireg);     // NOLINT
     __m256i R_factor = _mm256_lddqu_si256(reinterpret_cast<__m256i*>(state.RS_memory_factor) + ireg);     // NOLINT
+    __m256i scale_factor = _mm256_lddqu_si256(reinterpret_cast<__m256i*>(state.RS_scale_factor) + ireg);     // NOLINT
 
     // ------------------------------------
     // Variables for hit finding

--- a/include/fdreadoutlibs/wibeth/tpg/ProcessStandardRSAVX2.hpp
+++ b/include/fdreadoutlibs/wibeth/tpg/ProcessStandardRSAVX2.hpp
@@ -26,13 +26,6 @@ process_window_standard_rs_avx2(ProcessingInfo<NREGISTERS>& info)
   const __m256i overflowMax = _mm256_set1_epi16(INT16_MAX);
       
 
-  // Running sum scaling factor
-  //const __m256i R_factor = _mm256_set1_epi16(info.rs_memory_factor);
-
-  // Scaling factor to stop the ADCs from overflowing 
-  // (may not needs this, depends on magnitude of FIR output) 
-  //const __m256i scale_factor = _mm256_set1_epi16(info.rs_scale_factor);
-
   // The maximum value that sigma can have before the threshold overflows a 16-bit signed integer
   //const __m256i sigmaMax = _mm256_set1_epi16((1 << 15) / (info.multiplier * info.threshold));
 

--- a/include/fdreadoutlibs/wibeth/tpg/ProcessingInfo.hpp
+++ b/include/fdreadoutlibs/wibeth/tpg/ProcessingInfo.hpp
@@ -30,6 +30,7 @@ struct ChanState
       pedestalsRS[i] = 0;      
       accumRS[i] = 0;
       RS_memory_factor[i] = 0;
+      RS_scale_factor[i] = 0;
       accum25[i] = 0;
       accum75[i] = 0;
       prev_was_over[i] = 0;
@@ -49,6 +50,7 @@ struct ChanState
   alignas(32) int16_t __restrict__ pedestalsRS[NREGISTERS * SAMPLES_PER_REGISTER];
   alignas(32) int16_t __restrict__ accumRS[NREGISTERS * SAMPLES_PER_REGISTER];
   alignas(32) uint16_t __restrict__ RS_memory_factor[NREGISTERS * SAMPLES_PER_REGISTER];
+  alignas(32) uint16_t __restrict__ RS_scale_factor[NREGISTERS * SAMPLES_PER_REGISTER];
 
 
   //Variables for IQR
@@ -76,8 +78,6 @@ struct ProcessingInfo
                  uint8_t last_register_,            // NOLINT
                  uint16_t* __restrict__ output_,    // NOLINT
                  const uint8_t exponent_, // NOLINT
-                 uint16_t rs_memory_factor_, // NOLINT
-                 uint16_t rs_scale_factor_, // NOLINT
                  int16_t frugal_streaming_accumulator_limit_, // NOLINT 
                  size_t nhits_
                 ) // NOLINT
@@ -87,8 +87,6 @@ struct ProcessingInfo
     , last_register(last_register_)
     , output(output_)
     , exponent(exponent_)
-    , rs_memory_factor(rs_memory_factor_)
-    , rs_scale_factor(rs_scale_factor_)
     , frugal_streaming_accumulator_limit(frugal_streaming_accumulator_limit_)
     , multiplier(1 << exponent)
     , adcMax(INT16_MAX / multiplier)
@@ -108,18 +106,28 @@ struct ProcessingInfo
 
   }
 
+  void setRunningSumState(std::array<uint16_t, swtpg_wibeth::NUM_REGISTERS_PER_FRAME * swtpg_wibeth::SAMPLES_PER_REGISTER>& register_memory_factor,
+                          std::array<uint16_t, swtpg_wibeth::NUM_REGISTERS_PER_FRAME * swtpg_wibeth::SAMPLES_PER_REGISTER>& register_scale_factor)
+  {
+    // Set the RS memory and scale factors.
+    for (size_t j = 0; j < NREGISTERS * SAMPLES_PER_REGISTER; ++j) {
+      const size_t i = IOTA[j % SAMPLES_PER_REGISTER];
+      const size_t reg_idx = j / SAMPLES_PER_REGISTER;
+      chanState.RS_memory_factor[j] = register_memory_factor[i + reg_idx * SAMPLES_PER_REGISTER];
+      chanState.RS_scale_factor[j] = register_scale_factor[i + reg_idx * SAMPLES_PER_REGISTER];
+    }
+  }
+
   // Set the initial state from the window starting at first_msg_p
   template<size_t N>
-  void setState(const RegisterArray<N>& first_tick_registers, 
-                std::array<uint16_t, swtpg_wibeth::NUM_REGISTERS_PER_FRAME * swtpg_wibeth::SAMPLES_PER_REGISTER>& register_memory_factor
-               )
+  void setState(const RegisterArray<N>& first_tick_registers)
   {
     static_assert(N >= NREGISTERS, "Wrong array size");
 
     // AAA: Loop through all the registers, loop through all the channels, look at the 
     // first message of the superchunk and read the ADC value. This will be used as the 
     // pedestal for the channel state
-    std::cout << "Printing values of the memory factor: ";
+    //std::cout << "Printing values of the memory factor: ";
     for (size_t j = 0; j < NREGISTERS * SAMPLES_PER_REGISTER; ++j) {
       const size_t register_offset = j % SAMPLES_PER_REGISTER; 
       const size_t register_index = j / SAMPLES_PER_REGISTER;
@@ -141,9 +149,6 @@ struct ProcessingInfo
         break; // breaking in order to select only the first entry
       }
 
-      // Set up the channel state for the memory factor
-      chanState.RS_memory_factor[j] = register_memory_factor[j];
-    
       // Set the pedestals and the 25/75-percentiles
       chanState.pedestals[j] = ped;
       chanState.pedestalsRS[j] = 0;
@@ -155,7 +160,7 @@ struct ProcessingInfo
       chanState.quantile25[j] = ped-20;
       chanState.quantile75[j] = ped+20;
     }
-    std::cout << '\n' ;
+    //std::cout << '\n' ;
     
   }  
 
@@ -165,8 +170,6 @@ struct ProcessingInfo
   uint8_t last_register;         // NOLINT
   uint16_t* __restrict__ output; // NOLINT
   uint8_t exponent; // NOLINT
-  uint16_t rs_memory_factor;   // NOLINT
-  uint16_t rs_scale_factor;   // NOLINT
   int16_t frugal_streaming_accumulator_limit;   // NOLINT
 
 

--- a/src/wibeth/WIBEthFrameProcessor.cpp
+++ b/src/wibeth/WIBEthFrameProcessor.cpp
@@ -72,7 +72,7 @@ WIBEthFrameHandler::reset()
 }
 
 void
-WIBEthFrameHandler::initialize(uint16_t memory_factor, uint16_t scale_factor, int16_t frug_streaming_acclimt)
+WIBEthFrameHandler::initialize(int16_t frug_streaming_acclimt)
 {
 
   if(m_hits_dest == nullptr) {m_hits_dest = new uint16_t[100000];}
@@ -83,8 +83,6 @@ WIBEthFrameHandler::initialize(uint16_t memory_factor, uint16_t scale_factor, in
                                                                                                             swtpg_wibeth::NUM_REGISTERS_PER_FRAME,
                                                                                                             m_hits_dest,
                                                                                                             m_tpg_exponent,
-                                                                                                            memory_factor,
-                                                                                                            scale_factor,
                                                                                                             frug_streaming_acclimt,
                                                                                                             0);
 }
@@ -115,10 +113,7 @@ WIBEthFrameProcessor::start(const nlohmann::json& args)
     m_tps_suppressed_too_long = 0;
     m_tps_send_failed = 0;
 
-    m_wibeth_frame_handler->initialize(m_tpg_rs_memory_factor,
-                                       m_tpg_rs_scale_factor,
-                                       m_tpg_frugal_streaming_accumulator_limit
-                                       );
+    m_wibeth_frame_handler->initialize(m_tpg_frugal_streaming_accumulator_limit);
   } // end if(m_tpg_enabled)
 
   // Reset timestamp check
@@ -183,13 +178,9 @@ WIBEthFrameProcessor::conf(const nlohmann::json& cfg)
   } else if (m_tpg_algorithm == "AbsRS" ) {
     m_tp_algo = trgdataformats::TriggerPrimitive::Algorithm::kAbsRunningSum;
     m_assigned_tpg_algorithm_function = &swtpg_wibeth::process_window_rs_avx2<swtpg_wibeth::NUM_REGISTERS_PER_FRAME>;
-    // Enable simple threshold on plane 2 is used only if you are using a Running Sum algorithm
-    m_enable_simple_threshold_on_plane2 = config.enable_simple_threshold_on_plane2;
   }  else if (m_tpg_algorithm == "StandardRS" ) {
     m_tp_algo = trgdataformats::TriggerPrimitive::Algorithm::kRunningSum;
     m_assigned_tpg_algorithm_function = &swtpg_wibeth::process_window_standard_rs_avx2<swtpg_wibeth::NUM_REGISTERS_PER_FRAME>;
-    // Enable simple threshold on plane 2 is used only if you are using a Running Sum algorithm
-    m_enable_simple_threshold_on_plane2 = config.enable_simple_threshold_on_plane2;
   } else {
     throw TPGAlgorithmInexistent(ERS_HERE, m_tpg_algorithm);
   }
@@ -197,15 +188,36 @@ WIBEthFrameProcessor::conf(const nlohmann::json& cfg)
   // Extract algorithm specif configurations
   // AAA: In the Running Sum algorithms, we multiply everything by 10 
   // in order to deal with only integers instead of floats
-  m_tpg_rs_memory_factor = 10*config.tpg_rs_memory_factor;
+  // Use the default if the plane isn't specified.
+  m_tpg_rs_memory_factor_plane2 = config.tpg_rs_memory_factor_plane2 != -1 ? 10*config.tpg_rs_memory_factor_plane2
+                                                                           : 10*config.tpg_rs_memory_factor_default;
+
+  m_tpg_rs_memory_factor_plane1 = config.tpg_rs_memory_factor_plane1 != -1 ? 10*config.tpg_rs_memory_factor_plane1
+                                                                           : 10*config.tpg_rs_memory_factor_default;
+
+  m_tpg_rs_memory_factor_plane0 = config.tpg_rs_memory_factor_plane0 != -1 ? 10*config.tpg_rs_memory_factor_plane0
+                                                                           : 10*config.tpg_rs_memory_factor_default;
 
   // In the Running Sum algorithms we divide by the scale factor and multiply by 10
-  // Potential mismatch when using 
-  m_tpg_rs_scale_factor  = 10/config.tpg_rs_scale_factor;
+  // Use the default if the plane isn't specified.
+  m_tpg_rs_scale_factor_plane2 = config.tpg_rs_scale_factor_plane2 ? 10/config.tpg_rs_scale_factor_plane2
+                                                                   : 10/config.tpg_rs_scale_factor_default;
+
+  m_tpg_rs_scale_factor_plane1 = config.tpg_rs_scale_factor_plane1 ? 10/config.tpg_rs_scale_factor_plane1
+                                                                   : 10/config.tpg_rs_scale_factor_default;
+
+  m_tpg_rs_scale_factor_plane0 = config.tpg_rs_scale_factor_plane0 ? 10/config.tpg_rs_scale_factor_plane0
+                                                                   : 10/config.tpg_rs_scale_factor_default;
 
   m_tpg_frugal_streaming_accumulator_limit = config.tpg_frugal_streaming_accumulator_limit;
-  TLOG_DEBUG(TLVL_BOOKKEEPING) << "RS memory factor " << m_tpg_rs_memory_factor;
-  TLOG_DEBUG(TLVL_BOOKKEEPING) << "RS scale factor " << m_tpg_rs_scale_factor;
+  TLOG_DEBUG(TLVL_BOOKKEEPING) << "RS memory factors (0, 1, 2): "
+                               << m_tpg_rs_memory_factor_plane0 << ", "
+                               << m_tpg_rs_memory_factor_plane1 << ", "
+                               << m_tpg_rs_memory_factor_plane2 << ".";
+  TLOG_DEBUG(TLVL_BOOKKEEPING) << "RS scale factors (0, 1, 2): "
+                               << m_tpg_rs_scale_factor_plane0 << ", "
+                               << m_tpg_rs_scale_factor_plane1 << ", "
+                               << m_tpg_rs_scale_factor_plane2 << ".";
   TLOG_DEBUG(TLVL_BOOKKEEPING) << "Frugal streaming acc limit " << m_tpg_frugal_streaming_accumulator_limit; 
 
   m_tp_max_width = config.tp_timeout;
@@ -439,15 +451,18 @@ WIBEthFrameProcessor::find_hits(constframeptr fp, WIBEthFrameHandler* frame_hand
       auto chan_value = frame_handler->register_channel_map.channel[i];
       m_register_channels[i] = chan_value;
 
+      // Set all the waveform evaluation and manipulation by plane.
       if (m_channel_map->get_plane_from_offline_channel(chan_value) == 2 ) {
-        // If SimpleThreshold on plane 2, then set the memory factor to 0, else use the common memory factor.
-        m_register_memory_factor[i] = m_enable_simple_threshold_on_plane2 ? 0 : m_tpg_rs_memory_factor;
+        m_register_memory_factor[i] = m_tpg_rs_memory_factor_plane2;
+        m_register_scale_factor[i] = m_tpg_rs_scale_factor_plane2;
         m_tpg_threshold[i] = m_tpg_threshold_plane2;
       } else if (m_channel_map->get_plane_from_offline_channel(chan_value) == 1) {
-        m_register_memory_factor[i] = m_tpg_rs_memory_factor;
+        m_register_memory_factor[i] = m_tpg_rs_memory_factor_plane1;
+        m_register_scale_factor[i] = m_tpg_rs_scale_factor_plane1;
         m_tpg_threshold[i] = m_tpg_threshold_plane1;
       } else {
-        m_register_memory_factor[i] = m_tpg_rs_memory_factor;
+        m_register_memory_factor[i] = m_tpg_rs_memory_factor_plane0;
+        m_register_scale_factor[i] = m_tpg_rs_scale_factor_plane0;
         m_tpg_threshold[i] = m_tpg_threshold_plane0;
       }
 
@@ -458,7 +473,8 @@ WIBEthFrameProcessor::find_hits(constframeptr fp, WIBEthFrameHandler* frame_hand
     }
 
     frame_handler->m_tpg_processing_info->setThresholdState(m_tpg_threshold);
-    frame_handler->m_tpg_processing_info->setState(registers_array, m_register_memory_factor);
+    frame_handler->m_tpg_processing_info->setRunningSumState(m_register_memory_factor, m_register_scale_factor);
+    frame_handler->m_tpg_processing_info->setState(registers_array);
 
 
     // Set first hit bool to false so that registration of channel map is not executed twice


### PR DESCRIPTION
Running sum memory and scale factors are now configurable by plane.

This PR is very similar to #177, but this time affecting the RS memory and scale factors. Testing was done online and verifying that the TPs generated were _acceptable_ to the given configuration. It is difficult to account for the online median estimation, so the quality check was on edge cases of `tpg_rs_memory_factor_planeX = 0` and `tpg_rs_scale_factor_planeX = 1` or `10`. This was done for both `StandardRS` and `AbsRS`. Both implementations are consistent with these edge cases,  and the expected running values of 0.8, 0.9 for the memory factor and 2 for the scale factor produced results that appeared consistent before the change.

There are linked PRs in [daqconf](https://github.com/DUNE-DAQ/daqconf/pull/457), [fddaqconf](https://github.com/DUNE-DAQ/fddaqconf/compare/patch/fddaq-v4.4.x...aeo/tpg-rs-scale-by-plane), [readoutlibs](https://github.com/DUNE-DAQ/readoutlibs/pull/170), and [tpgtools](https://github.com/DUNE-DAQ/tpgtools/pull/32) for the updates in configurables and emulation.