### PR TITLE
Branch for peak integral redefinition from Alex

### DIFF
--- a/include/fdreadoutlibs/wibeth/tpg/ProcessAbsRSAVX2.hpp
+++ b/include/fdreadoutlibs/wibeth/tpg/ProcessAbsRSAVX2.hpp
@@ -195,7 +195,7 @@ process_window_rs_avx2(ProcessingInfo<NREGISTERS>& info)
       // Really want an epi16 version of this, but the cmpgt and
       // cmplt functions set their epi16 parts to 0xff or 0x0,
       // so treating everything as epi8 works the same
-      __m256i to_add_charge = _mm256_blendv_epi8(_mm256_set1_epi16(0), s, is_over);
+      __m256i to_add_charge = _mm256_blendv_epi8(_mm256_set1_epi16(0), RS, is_over);
       hit_charge = _mm256_adds_epi16(hit_charge, to_add_charge);
 
       // Avoid overflow of the hit charge, if needed in practice 
@@ -217,8 +217,8 @@ process_window_rs_avx2(ProcessingInfo<NREGISTERS>& info)
       //}
 
       // 1. Calculation of the hit peak time and ADC
-      __m256i is_sample_over_adc_peak = _mm256_cmpgt_epi16(s, hit_peak_adc);
-      hit_peak_adc = _mm256_blendv_epi8(hit_peak_adc, s, is_sample_over_adc_peak); 
+      __m256i is_sample_over_adc_peak = _mm256_cmpgt_epi16(RS, hit_peak_adc);
+      hit_peak_adc = _mm256_blendv_epi8(hit_peak_adc, RS, is_sample_over_adc_peak);
       hit_peak_time = _mm256_blendv_epi8(hit_peak_time, hit_tover, is_sample_over_adc_peak);
 
       // 2. Update of the hit time over threshold  

--- a/include/fdreadoutlibs/wibeth/tpg/ProcessNaiveRS.hpp
+++ b/include/fdreadoutlibs/wibeth/tpg/ProcessNaiveRS.hpp
@@ -121,10 +121,10 @@ process_window_naive_RS(ProcessingInfo<NREGISTERS>& info)
       if (is_over) {
         // Simulate saturated add
         int32_t tmp_charge = hit_charge;
-	tmp_charge += sample;
+	tmp_charge += RS;
         tmp_charge = std::min(tmp_charge, (int32_t)std::numeric_limits<int16_t>::max());
-        if (sample > hit_peak_adc) {
-          hit_peak_adc = (uint16_t)sample;
+        if (RS > hit_peak_adc) {
+          hit_peak_adc = (uint16_t)RS;
           hit_peak_time = hit_tover;
         }
         hit_charge = (int16_t)tmp_charge;

--- a/include/fdreadoutlibs/wibeth/tpg/ProcessStandardRSAVX2.hpp
+++ b/include/fdreadoutlibs/wibeth/tpg/ProcessStandardRSAVX2.hpp
@@ -189,7 +189,7 @@ process_window_standard_rs_avx2(ProcessingInfo<NREGISTERS>& info)
       // Really want an epi16 version of this, but the cmpgt and
       // cmplt functions set their epi16 parts to 0xff or 0x0,
       // so treating everything as epi8 works the same
-      __m256i to_add_charge = _mm256_blendv_epi8(_mm256_set1_epi16(0), s, is_over);
+      __m256i to_add_charge = _mm256_blendv_epi8(_mm256_set1_epi16(0), RS, is_over);
       hit_charge = _mm256_adds_epi16(hit_charge, to_add_charge);
 
       // Avoid overflow of the hit charge, if needed in practice 
@@ -211,8 +211,8 @@ process_window_standard_rs_avx2(ProcessingInfo<NREGISTERS>& info)
       //}
 
       // 1. Calculation of the hit peak time and ADC
-      __m256i is_sample_over_adc_peak = _mm256_cmpgt_epi16(s, hit_peak_adc);
-      hit_peak_adc = _mm256_blendv_epi8(hit_peak_adc, s, is_sample_over_adc_peak); 
+      __m256i is_sample_over_adc_peak = _mm256_cmpgt_epi16(RS, hit_peak_adc);
+      hit_peak_adc = _mm256_blendv_epi8(hit_peak_adc, RS, is_sample_over_adc_peak);
       hit_peak_time = _mm256_blendv_epi8(hit_peak_time, hit_tover, is_sample_over_adc_peak);
 
       // 2. Update of the hit time over threshold  


### PR DESCRIPTION
The TP peak and integral are computed using the standard running sum ADC values instead of the raw ADC values.  
We have been running for several days at NP04 HD commissioning with this branch and have not encountered any operational issues. 
We have also confirmed that the StandardRS when configured with R = 0.0 (memory factor), behaves as the SimpleThreshold algorithm. 
The small differences that were noticeable in the TP rate plots are found to be due to the 2-nd pedestal subtraction that needs to be performed when we use the Running Sum algorithms.

Thresholding has been on the RS curve. However, the ADC peak (time peak) and integral were on the original waveform. This changes to use the RS curve. 
So in principle this will not change the number of TPs made or how the TPs are made, it will just change the ADCIntegral & ADCPeak values that the TriggerPrimitive object is carrying. 
However, since TAs/TCs can make use of integral and peak information, this will affect any logic there.

PRs for the dependent repositories will be also made [links to be provided here. There are NONE].
To safely apply this, readoutlibs, readoutmodules, and fdreadoutmodules should also be built.