### PR TITLE
TPG accumulator initialization fix

### DIFF
--- a/include/fdreadoutlibs/wibeth/tpg/ProcessAbsRSAVX2.hpp
+++ b/include/fdreadoutlibs/wibeth/tpg/ProcessAbsRSAVX2.hpp
@@ -195,7 +195,7 @@ process_window_rs_avx2(ProcessingInfo<NREGISTERS>& info)
       // Really want an epi16 version of this, but the cmpgt and
       // cmplt functions set their epi16 parts to 0xff or 0x0,
       // so treating everything as epi8 works the same
-      __m256i to_add_charge = _mm256_blendv_epi8(_mm256_set1_epi16(0), s, is_over);
+      __m256i to_add_charge = _mm256_blendv_epi8(_mm256_set1_epi16(0), RS, is_over);
       hit_charge = _mm256_adds_epi16(hit_charge, to_add_charge);
 
       // Avoid overflow of the hit charge, if needed in practice 
@@ -217,8 +217,8 @@ process_window_rs_avx2(ProcessingInfo<NREGISTERS>& info)
       //}
 
       // 1. Calculation of the hit peak time and ADC
-      __m256i is_sample_over_adc_peak = _mm256_cmpgt_epi16(s, hit_peak_adc);
-      hit_peak_adc = _mm256_blendv_epi8(hit_peak_adc, s, is_sample_over_adc_peak); 
+      __m256i is_sample_over_adc_peak = _mm256_cmpgt_epi16(RS, hit_peak_adc);
+      hit_peak_adc = _mm256_blendv_epi8(hit_peak_adc, RS, is_sample_over_adc_peak);
       hit_peak_time = _mm256_blendv_epi8(hit_peak_time, hit_tover, is_sample_over_adc_peak);
 
       // 2. Update of the hit time over threshold  

--- a/include/fdreadoutlibs/wibeth/tpg/ProcessNaiveRS.hpp
+++ b/include/fdreadoutlibs/wibeth/tpg/ProcessNaiveRS.hpp
@@ -121,10 +121,10 @@ process_window_naive_RS(ProcessingInfo<NREGISTERS>& info)
       if (is_over) {
         // Simulate saturated add
         int32_t tmp_charge = hit_charge;
-	tmp_charge += sample;
+	tmp_charge += RS;
         tmp_charge = std::min(tmp_charge, (int32_t)std::numeric_limits<int16_t>::max());
-        if (sample > hit_peak_adc) {
-          hit_peak_adc = (uint16_t)sample;
+        if (RS > hit_peak_adc) {
+          hit_peak_adc = (uint16_t)RS;
           hit_peak_time = hit_tover;
         }
         hit_charge = (int16_t)tmp_charge;

--- a/include/fdreadoutlibs/wibeth/tpg/ProcessStandardRSAVX2.hpp
+++ b/include/fdreadoutlibs/wibeth/tpg/ProcessStandardRSAVX2.hpp
@@ -189,7 +189,7 @@ process_window_standard_rs_avx2(ProcessingInfo<NREGISTERS>& info)
       // Really want an epi16 version of this, but the cmpgt and
       // cmplt functions set their epi16 parts to 0xff or 0x0,
       // so treating everything as epi8 works the same
-      __m256i to_add_charge = _mm256_blendv_epi8(_mm256_set1_epi16(0), s, is_over);
+      __m256i to_add_charge = _mm256_blendv_epi8(_mm256_set1_epi16(0), RS, is_over);
       hit_charge = _mm256_adds_epi16(hit_charge, to_add_charge);
 
       // Avoid overflow of the hit charge, if needed in practice 
@@ -211,8 +211,8 @@ process_window_standard_rs_avx2(ProcessingInfo<NREGISTERS>& info)
       //}
 
       // 1. Calculation of the hit peak time and ADC
-      __m256i is_sample_over_adc_peak = _mm256_cmpgt_epi16(s, hit_peak_adc);
-      hit_peak_adc = _mm256_blendv_epi8(hit_peak_adc, s, is_sample_over_adc_peak); 
+      __m256i is_sample_over_adc_peak = _mm256_cmpgt_epi16(RS, hit_peak_adc);
+      hit_peak_adc = _mm256_blendv_epi8(hit_peak_adc, RS, is_sample_over_adc_peak);
       hit_peak_time = _mm256_blendv_epi8(hit_peak_time, hit_tover, is_sample_over_adc_peak);
 
       // 2. Update of the hit time over threshold  

--- a/include/fdreadoutlibs/wibeth/tpg/ProcessingInfo.hpp
+++ b/include/fdreadoutlibs/wibeth/tpg/ProcessingInfo.hpp
@@ -151,6 +151,10 @@ struct ProcessingInfo
 
       // Set the pedestals and the 25/75-percentiles
       chanState.pedestals[j] = ped;
+      chanState.accum[j] = 0;
+      chanState.hit_tover[j] = 0;
+      chanState.hit_charge[j] = 0;
+
       chanState.pedestalsRS[j] = 0;
       chanState.RS[j] = 0;
       // AAA: Quantiles are set to the pedestal value +/- 20 so that the IQR 


### PR DESCRIPTION
This branch is based on Alex's branch requested here https://github.com/DUNE-DAQ/fdreadoutlibs/pull/182

At TPG algorithm initialization, the pedestal value is set to the first ADC value in the WIB frame.
In this branch, we also set the accumulator value to 0. This helps to compare offline emulation with the data collected online.  

The branch has been tested at NP04 HD test and overnight runs. 