### PR TITLE
Change in the use of the TPChannelInfo

### DIFF
--- a/src/wibeth/WIBEthFrameProcessor.cpp
+++ b/src/wibeth/WIBEthFrameProcessor.cpp
@@ -279,13 +279,10 @@ WIBEthFrameProcessor::get_info(opmonlib::InfoCollector& ci, int level)
         top_highest_values = channel_tp_rate_vec.size();
       }
       for (int i = 0; i < top_highest_values; i++) {
-        std::stringstream info_name;
-        info_name << "channel_" << channel_tp_rate_vec[i].first;
-        opmonlib::InfoCollector tmp_ic;
         readoutlibs::readoutinfo::TPChannelInfo tp_info;
         tp_info.num_tp = channel_tp_rate_vec[i].second;
-        tmp_ic.add(tp_info);
-        ci.add(info_name.str(), tmp_ic);
+	tp_info.channel = channel_tp_rate_vec[i].first;
+        ci.add(tp_info);
       }
     }
 


### PR DESCRIPTION
Fix to avoid the collapse of the monitoring. It requires https://github.com/DUNE-DAQ/readoutlibs/pull/179