### PR TITLE
Achieve 1-1 matching of AVX2 and NAIVE TPG

### DIFF
--- a/include/fdreadoutlibs/wibeth/tpg/ProcessAbsRSAVX2.hpp
+++ b/include/fdreadoutlibs/wibeth/tpg/ProcessAbsRSAVX2.hpp
@@ -129,23 +129,17 @@ process_window_rs_avx2(ProcessingInfo<NREGISTERS>& info)
 
       // Instead of using floats in the calcualation of the RS we multiply by 10 and 
       // do operations on the integers. In the end we divide by 10. 
-
+     
      __m256i first_part = _mm256_mullo_epi16(RS, R_factor);
-     //__m256i first_part_div = _mm256_div_epi16(RS, 10);
+     __m256i first_part_div = _mm256_div_epi16(first_part, 10);
 
      __m256i second_part = _mm256_mullo_epi16(_mm256_abs_epi16(s), scale_factor);
-     //__m256i second_part_div = _mm256_div_epi16(_mm256_abs_epi16(s), 10);
+     __m256i second_part_div = _mm256_div_epi16(second_part, 10);
 
-     //RS = _mm256_div_epi16(_mm256_add_epi16(first_part, second_part), 10);
-     RS = swtpg_wibeth::_mm256_div_epi16(_mm256_add_epi16(first_part, second_part), 10);
-
-     //printf("first_part:\t\t\t\t"); print256_as16_dec(first_part);         printf("\n"); 
-     //printf("second_part:\t\t\t\t"); print256_as16_dec(second_part);         printf("\n"); 
-     //printf("RS_value:\t\t\t\t"); print256_as16_dec(RS);         printf("\n"); 
+     RS = _mm256_add_epi16(first_part_div, second_part_div);
 
       // Update the medianRS itself in all channels
-      //printf("MedianRS:\t\t\t\t"); print256_as16_dec(medianRS);         printf("\n"); 
-
+       
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Woverflow"
       swtpg_wibeth::frugal_accum_update_avx2(medianRS, RS, accumRS, info.frugal_streaming_accumulator_limit, _mm256_set1_epi16(0xffff));
@@ -153,10 +147,6 @@ process_window_rs_avx2(ProcessingInfo<NREGISTERS>& info)
 
       // __m256i sigma = _mm256_set1_epi16(2000); // 20 ADC
       RS = _mm256_sub_epi16(RS, medianRS);
-
-      //printf("RS_after_medianRS:\t\t\t\t"); print256_as16_dec(RS);         printf("\n"); 
-
-
 
       // --------------------------------------------------------------
       // Inter-quantile range
@@ -168,7 +158,6 @@ process_window_rs_avx2(ProcessingInfo<NREGISTERS>& info)
       // Clamp sigma to a range where it won't overflow when
       // multiplied by info.multiplier*5
       //sigma = _mm256_min_epi16(sigma, sigmaMax);
-
 
 
       // --------------------------------------------------------------
@@ -203,17 +192,12 @@ process_window_rs_avx2(ProcessingInfo<NREGISTERS>& info)
 
 
       //if(ireg==0){
-      //     printf("itime=%ld\n", itime);
-      //     printf("s:             "); print256_as16_dec(s);             printf("\n");
-      //     printf("median:        "); print256_as16_dec(median);        printf("\n");
-      //     printf("RS:         "); print256_as16_dec(RS);         printf("\n");
-      //     printf("sigma:         "); print256_as16_dec(sigma);         printf("\n");
-      //     printf("filt:          "); print256_as16_dec(filt);          printf("\n");
-      //     printf("to_add_charge: "); print256_as16_dec(to_add_charge); printf("\n");
-      //     printf("hit_charge:    "); print256_as16_dec(hit_charge);    printf("\n");
-      //     printf("channels:    "); print256_as16_dec(channels);    printf("\n");     
-      //     printf("is_over:          "); print256_as16_dec(is_over);          printf("\n");
-      //     printf("left:          "); print256_as16_dec(left);          printf("\n");
+           //printf("-------------------------------------\n", itime);
+           //printf("hit_charge:    "); print256_as16_dec(hit_charge);    printf("\n");
+           //printf("hit_peak_adc:    "); print256_as16_dec(hit_peak_adc);    printf("\n");
+           //printf("threshold:        "); print256_as16_dec(threshold);        printf("\n");
+           //printf("R_factor:        "); print256_as16_dec(R_factor);        printf("\n");
+           //printf("scale_factor:        "); print256_as16_dec(scale_factor);        printf("\n");
       //}
 
       // 1. Calculation of the hit peak time and ADC
@@ -246,7 +230,6 @@ process_window_rs_avx2(ProcessingInfo<NREGISTERS>& info)
 
       if (!no_hits_to_store) {
 
-
         ++nhits;
         // We have to save the whole register, including the
         // lanes that don't have anything interesting, but
@@ -271,9 +254,11 @@ process_window_rs_avx2(ProcessingInfo<NREGISTERS>& info)
 
         _mm256_storeu_si256(output_loc++, timenow); // NOLINT(runtime/increment_decrement)
         // STORE_MASK(hit_charge);
-        _mm256_storeu_si256(output_loc++, // NOLINT(runtime/increment_decrement)
-                            _mm256_blendv_epi8(_mm256_set1_epi16(0), hit_charge, left));
-        _mm256_storeu_si256(output_loc++, hit_tover); // NOLINT(runtime/increment_decrement)
+        //_mm256_storeu_si256(output_loc++, // NOLINT(runtime/increment_decrement)
+        //                    _mm256_blendv_epi8(_mm256_set1_epi16(0), hit_charge, left));
+        _mm256_storeu_si256(output_loc++, hit_charge);
+
+	_mm256_storeu_si256(output_loc++, hit_tover); // NOLINT(runtime/increment_decrement)
 
         _mm256_storeu_si256(output_loc++, hit_peak_adc); // NOLINT(runtime/increment_decrement)
 

--- a/include/fdreadoutlibs/wibeth/tpg/ProcessAbsRSAVX2.hpp
+++ b/include/fdreadoutlibs/wibeth/tpg/ProcessAbsRSAVX2.hpp
@@ -146,7 +146,7 @@ process_window_rs_avx2(ProcessingInfo<NREGISTERS>& info)
       __m256i second_part = _mm256_div_epi16(_mm256_abs_epi16(s), 10);
       second_part = _mm256_mullo_epi16(second_part, scale_factor);
 
-      RS = _mm256_add_epi16(first_part, second_part);
+      RS = _mm256_adds_epi16(first_part, second_part);
 
       // Update the medianRS itself in all channels
        

--- a/include/fdreadoutlibs/wibeth/tpg/ProcessAbsRSAVX2.hpp
+++ b/include/fdreadoutlibs/wibeth/tpg/ProcessAbsRSAVX2.hpp
@@ -129,7 +129,8 @@ process_window_rs_avx2(ProcessingInfo<NREGISTERS>& info)
 
       // Instead of using floats in the calcualation of the RS we multiply by 10 and 
       // do operations on the integers. In the end we divide by 10. 
-     
+    
+      /* 
       __m256i first_part = _mm256_mullo_epi16(RS, R_factor);
       __m256i second_part = _mm256_mullo_epi16(_mm256_abs_epi16(s), scale_factor);
       //RS = swtpg_wibeth::_mm256_div_epi16(_mm256_add_epi16(first_part, second_part), 10);
@@ -137,7 +138,15 @@ process_window_rs_avx2(ProcessingInfo<NREGISTERS>& info)
       __m256i first_part_div = _mm256_div_epi16(first_part, 10);
       __m256i second_part_div = _mm256_div_epi16(second_part, 10);
       RS = _mm256_add_epi16(first_part_div, second_part_div);
+      */
 
+      __m256i first_part = _mm256_div_epi16(RS, 10);
+      first_part =_mm256_mullo_epi16(first_part, R_factor); 
+
+      __m256i second_part = _mm256_div_epi16(_mm256_abs_epi16(s), 10);
+      second_part = _mm256_mullo_epi16(second_part, scale_factor);
+
+      RS = _mm256_add_epi16(first_part, second_part);
 
       // Update the medianRS itself in all channels
        

--- a/include/fdreadoutlibs/wibeth/tpg/ProcessAbsRSAVX2.hpp
+++ b/include/fdreadoutlibs/wibeth/tpg/ProcessAbsRSAVX2.hpp
@@ -130,13 +130,14 @@ process_window_rs_avx2(ProcessingInfo<NREGISTERS>& info)
       // Instead of using floats in the calcualation of the RS we multiply by 10 and 
       // do operations on the integers. In the end we divide by 10. 
      
-     __m256i first_part = _mm256_mullo_epi16(RS, R_factor);
-     __m256i first_part_div = _mm256_div_epi16(first_part, 10);
+      __m256i first_part = _mm256_mullo_epi16(RS, R_factor);
+      __m256i second_part = _mm256_mullo_epi16(_mm256_abs_epi16(s), scale_factor);
+      //RS = swtpg_wibeth::_mm256_div_epi16(_mm256_add_epi16(first_part, second_part), 10);
 
-     __m256i second_part = _mm256_mullo_epi16(_mm256_abs_epi16(s), scale_factor);
-     __m256i second_part_div = _mm256_div_epi16(second_part, 10);
+      __m256i first_part_div = _mm256_div_epi16(first_part, 10);
+      __m256i second_part_div = _mm256_div_epi16(second_part, 10);
+      RS = _mm256_add_epi16(first_part_div, second_part_div);
 
-     RS = _mm256_add_epi16(first_part_div, second_part_div);
 
       // Update the medianRS itself in all channels
        

--- a/include/fdreadoutlibs/wibeth/tpg/ProcessNaive.hpp
+++ b/include/fdreadoutlibs/wibeth/tpg/ProcessNaive.hpp
@@ -37,6 +37,18 @@ frugal_accum_update(int16_t& m, const int16_t s, int16_t& acc, const int16_t acc
   }
 }
 
+int16_t
+naive_avx2_div(int16_t a, int16_t b)
+{
+  int16_t vb = (1 << 15) / b;
+  int32_t mulhrs = a * vb;
+  mulhrs = (mulhrs >> 14) + 1;
+  mulhrs = mulhrs >> 1;
+  int16_t va = (int16_t)(mulhrs);
+  return va;
+}
+
+
 template<size_t NREGISTERS>
 void
 process_window_naive(ProcessingInfo<NREGISTERS>& info)

--- a/include/fdreadoutlibs/wibeth/tpg/ProcessNaiveRS.hpp
+++ b/include/fdreadoutlibs/wibeth/tpg/ProcessNaiveRS.hpp
@@ -95,11 +95,20 @@ process_window_naive_RS(ProcessingInfo<NREGISTERS>& info)
       // Naive: RS = (R * RS) + std::abs(sample)/scale
       // RS = RS * RS_memory_factor + abs(sample) / RS_scale_factor;
 
+      /*
       int16_t first_part = (int16_t)(RS * RS_memory_factor);
       int16_t second_part = (int16_t)(std::abs(sample) * RS_scale_factor);
 
       first_part = naive_avx2_div(first_part, (int16_t)10);
       second_part = naive_avx2_div(second_part, (int16_t)10);
+      RS = (int16_t)(first_part + second_part);
+      */
+
+      int16_t first_part = naive_avx2_div(RS, (int16_t)10);
+      first_part = (int16_t)(first_part * RS_memory_factor);
+      int16_t second_part = naive_avx2_div(std::abs(sample), (int16_t)10);
+      second_part = (int16_t)(second_part * RS_scale_factor);
+
       RS = (int16_t)(first_part + second_part);
 
       //ss << "  \tFirst part: " << first_part;

--- a/include/fdreadoutlibs/wibeth/tpg/ProcessNaiveRS.hpp
+++ b/include/fdreadoutlibs/wibeth/tpg/ProcessNaiveRS.hpp
@@ -96,12 +96,10 @@ process_window_naive_RS(ProcessingInfo<NREGISTERS>& info)
       // RS = RS * RS_memory_factor + abs(sample) / RS_scale_factor;
 
       int16_t first_part = (int16_t)(RS * RS_memory_factor);
-      first_part = naive_avx2_div(first_part, (int16_t)10);
-
       int16_t second_part = (int16_t)(std::abs(sample) * RS_scale_factor);
+
+      first_part = naive_avx2_div(first_part, (int16_t)10);
       second_part = naive_avx2_div(second_part, (int16_t)10);
-
-
       RS = (int16_t)(first_part + second_part);
 
       //ss << "  \tFirst part: " << first_part;

--- a/include/fdreadoutlibs/wibeth/tpg/ProcessNaiveRS.hpp
+++ b/include/fdreadoutlibs/wibeth/tpg/ProcessNaiveRS.hpp
@@ -109,7 +109,8 @@ process_window_naive_RS(ProcessingInfo<NREGISTERS>& info)
       int16_t second_part = naive_avx2_div(std::abs(sample), (int16_t)10);
       second_part = (int16_t)(second_part * RS_scale_factor);
 
-      RS = (int16_t)(first_part + second_part);
+      int32_t overflow_part = first_part + second_part;
+      RS = std::min(overflow_part, INT16_MAX);
 
       //ss << "  \tFirst part: " << first_part;
       //ss << "  \tSecond part: " << second_part;

--- a/include/fdreadoutlibs/wibeth/tpg/ProcessNaiveStandardRS.hpp
+++ b/include/fdreadoutlibs/wibeth/tpg/ProcessNaiveStandardRS.hpp
@@ -49,7 +49,6 @@ process_window_naive_StandardRS(ProcessingInfo<NREGISTERS>& info)
     // Variables for hit finding
     int16_t& threshold = state.threshold[ichan]; // Threshold for this channel.
     uint16_t& RS_memory_factor = state.RS_memory_factor[ichan];
-    uint16_t& RS_scale_factor = state.RS_scale_factor[ichan];
     uint16_t& prev_was_over = state.prev_was_over[ichan]; // was the previous sample over threshold?
     uint16_t& hit_charge = state.hit_charge[ichan];
     uint16_t& hit_tover = state.hit_tover[ichan]; // time over threshold
@@ -85,7 +84,7 @@ process_window_naive_StandardRS(ProcessingInfo<NREGISTERS>& info)
       // Standard Running Sum
       //--------------------------------------------------------------
       
-      // Naive: RS = (R * RS) + sample/scale
+      // Naive: RS = (R * RS) + sample
       // RS = RS * RS_memory_factor + sample;
 
       int16_t first_part = (int16_t)(RS * RS_memory_factor);

--- a/include/fdreadoutlibs/wibeth/tpg/ProcessNaiveStandardRS.hpp
+++ b/include/fdreadoutlibs/wibeth/tpg/ProcessNaiveStandardRS.hpp
@@ -5,8 +5,8 @@
  * Licensing/copyright details are in the COPYING file that you should have
  * received with this code.
  */
-#ifndef READOUT_SRC_WIBETH_TPG_PROCESSNAIVERS_HPP_
-#define READOUT_SRC_WIBETH_TPG_PROCESSNAIVERS_HPP_
+#ifndef READOUT_SRC_WIBETH_TPG_PROCESSNAIVESTANDARDRS_HPP_
+#define READOUT_SRC_WIBETH_TPG_PROCESSNAIVESTANDARDRS_HPP_
 
 #include "FrameExpand.hpp"
 #include "ProcessingInfo.hpp"
@@ -16,13 +16,11 @@
 #include <inttypes.h>
 #include <limits>
 
-#include <cmath>
-
 namespace swtpg_wibeth {
 
 template<size_t NREGISTERS>
 void
-process_window_naive_RS(ProcessingInfo<NREGISTERS>& info)
+process_window_naive_StandardRS(ProcessingInfo<NREGISTERS>& info)
 {
   uint16_t* output_loc = info.output;           // NOLINT
   const uint16_t* input16 = info.input->data(); // NOLINT
@@ -93,17 +91,14 @@ process_window_naive_RS(ProcessingInfo<NREGISTERS>& info)
       //--------------------------------------------------------------
       
       // Naive: RS = (R * RS) + std::abs(sample)/scale
-      // RS = RS * RS_memory_factor + abs(sample) / RS_scale_factor;
+      // RS = RS * RS_memory_factor_float + sample / RS_scale_factor_float;
 
       int16_t first_part = (int16_t)(RS * RS_memory_factor);
-      first_part = naive_avx2_div(first_part, (int16_t)10);
+      first_part = naive_avx2_div(first_part, (uint16_t)10);
 
-      int16_t second_part = (int16_t)(std::abs(sample) * RS_scale_factor);
-      second_part = naive_avx2_div(second_part, (int16_t)10);
-
-
+      int16_t second_part = sample;
       RS = (int16_t)(first_part + second_part);
-
+ 
       //ss << "  \tFirst part: " << first_part;
       //ss << "  \tSecond part: " << second_part;
       //ss << "  \tRS value: " << RS;
@@ -111,8 +106,7 @@ process_window_naive_RS(ProcessingInfo<NREGISTERS>& info)
       // --------------------------------------------------------------
       // Second pedsub 
       // --------------------------------------------------------------      
-
-      frugal_accum_update(medianRS, RS, accumRS, 10);
+      frugal_accum_update(medianRS, RS, accumRS, 10); 
       //frugal_accum_update((int16_t&)medianRS, RS, (int16_t&)accumRS, 10);
       RS -= medianRS;
       //ss << "  \tMedianRS: " << medianRS ;
@@ -150,7 +144,7 @@ process_window_naive_RS(ProcessingInfo<NREGISTERS>& info)
         (*output_loc++) = hit_peak_adc;    // NOLINT
         (*output_loc++) = hit_peak_time;   // NOLINT        
 
-	hit_charge = 0;
+        hit_charge = 0;
         hit_tover = 0;
         hit_peak_adc = 0;
         hit_peak_time = 0;
@@ -185,4 +179,4 @@ process_window_naive_RS(ProcessingInfo<NREGISTERS>& info)
 
 } // namespace swtpg_wibeth
 
-#endif // READOUT_SRC_WIBETH_TPG_PROCESSNAIVERS_HPP_
+#endif // READOUT_SRC_WIBETH_TPG_PROCESSNAIVESTANDARDRS_HPP_

--- a/include/fdreadoutlibs/wibeth/tpg/ProcessNaiveStandardRS.hpp
+++ b/include/fdreadoutlibs/wibeth/tpg/ProcessNaiveStandardRS.hpp
@@ -1,5 +1,5 @@
 /**
- * @file ProcessNaiveRS.hpp Non AVX implementation of AbsRS tpg algorithm
+ * @file ProcessNaiveRS.hpp Non AVX implementation of StandardRS tpg algorithm
  *
  * This is part of the DUNE DAQ , copyright 2020.
  * Licensing/copyright details are in the COPYING file that you should have
@@ -45,11 +45,6 @@ process_window_naive_StandardRS(ProcessingInfo<NREGISTERS>& info)
     int16_t& RS         = state.RS[ichan]; //value of the RS for the previous sample
     int16_t& medianRS   = state.pedestalsRS[ichan]; //median for the RS waveform needed for IQR & separate pedsub
     int16_t& accumRS    = state.accumRS[ichan];
-    //IQR
-    //int16_t& accum25    = state.accum25[ichan];
-    //int16_t& accum75    = state.accum75[ichan];
-    //int16_t& quantile25 = state.quantile25[ichan];
-    //int16_t& quantile75 = state.quantile75[ichan];
 
     // Variables for hit finding
     int16_t& threshold = state.threshold[ichan]; // Threshold for this channel.
@@ -87,14 +82,14 @@ process_window_naive_StandardRS(ProcessingInfo<NREGISTERS>& info)
       //ss << "\tsample: " << sample;
 
       //--------------------------------------------------------------
-      // Absolute Running Sum
+      // Standard Running Sum
       //--------------------------------------------------------------
       
-      // Naive: RS = (R * RS) + std::abs(sample)/scale
-      // RS = RS * RS_memory_factor_float + sample / RS_scale_factor_float;
+      // Naive: RS = (R * RS) + sample/scale
+      // RS = RS * RS_memory_factor + sample;
 
       int16_t first_part = (int16_t)(RS * RS_memory_factor);
-      first_part = naive_avx2_div(first_part, (uint16_t)10);
+      first_part = naive_avx2_div(first_part, (int16_t)10);
 
       int16_t second_part = sample;
       RS = (int16_t)(first_part + second_part);

--- a/include/fdreadoutlibs/wibeth/tpg/ProcessNaiveStandardRS.hpp
+++ b/include/fdreadoutlibs/wibeth/tpg/ProcessNaiveStandardRS.hpp
@@ -1,5 +1,5 @@
 /**
- * @file ProcessNaiveRS.hpp Non AVX implementation of StandardRS tpg algorithm
+ * @file ProcessNaiveStandardRS.hpp Non AVX implementation of StandardRS tpg algorithm
  *
  * This is part of the DUNE DAQ , copyright 2020.
  * Licensing/copyright details are in the COPYING file that you should have

--- a/include/fdreadoutlibs/wibeth/tpg/ProcessStandardRSAVX2.hpp
+++ b/include/fdreadoutlibs/wibeth/tpg/ProcessStandardRSAVX2.hpp
@@ -207,8 +207,8 @@ process_window_standard_rs_avx2(ProcessingInfo<NREGISTERS>& info)
       //     printf("channels:    "); print256_as16_dec(channels);    printf("\n");     
       //     printf("is_over:          "); print256_as16_dec(is_over);          printf("\n");
       //     printf("left:          "); print256_as16_dec(left);          printf("\n");
-           //printf("threshold:        "); print256_as16_dec(threshold);        printf("\n");
-           //printf("R_factor:        "); print256_as16_dec(R_factor);        printf("\n");
+      //     printf("threshold:        "); print256_as16_dec(threshold);        printf("\n");
+      //     printf("R_factor:        "); print256_as16_dec(R_factor);        printf("\n");
       }
 
       // 1. Calculation of the hit peak time and ADC
@@ -268,7 +268,7 @@ process_window_standard_rs_avx2(ProcessingInfo<NREGISTERS>& info)
         // STORE_MASK(hit_charge);
         //_mm256_storeu_si256(output_loc++, // NOLINT(runtime/increment_decrement)
         //                    _mm256_blendv_epi8(_mm256_set1_epi16(0), hit_charge, left));
-        _mm256_storeu_si256(output_loc++, hit_charge);
+	_mm256_storeu_si256(output_loc++, hit_charge);
 
 	_mm256_storeu_si256(output_loc++, hit_tover); // NOLINT(runtime/increment_decrement)
 

--- a/include/fdreadoutlibs/wibeth/tpg/ProcessStandardRSAVX2.hpp
+++ b/include/fdreadoutlibs/wibeth/tpg/ProcessStandardRSAVX2.hpp
@@ -134,7 +134,6 @@ process_window_standard_rs_avx2(ProcessingInfo<NREGISTERS>& info)
      RS = _mm256_add_epi16(first_part, s);
 
      //printf("first_part:\t\t\t\t"); print256_as16_dec(first_part);         printf("\n"); 
-     //printf("second_part:\t\t\t\t"); print256_as16_dec(second_part);         printf("\n"); 
      //printf("RS_value:\t\t\t\t"); print256_as16_dec(RS);         printf("\n"); 
 
       // Update the medianRS itself in all channels
@@ -196,7 +195,7 @@ process_window_standard_rs_avx2(ProcessingInfo<NREGISTERS>& info)
       hit_charge = _mm256_min_epi16(hit_charge, overflowMax);
 
 
-      //if(ireg==0){
+      if(ireg==0){
       //     printf("itime=%ld\n", itime);
       //     printf("s:             "); print256_as16_dec(s);             printf("\n");
       //     printf("median:        "); print256_as16_dec(median);        printf("\n");
@@ -208,7 +207,9 @@ process_window_standard_rs_avx2(ProcessingInfo<NREGISTERS>& info)
       //     printf("channels:    "); print256_as16_dec(channels);    printf("\n");     
       //     printf("is_over:          "); print256_as16_dec(is_over);          printf("\n");
       //     printf("left:          "); print256_as16_dec(left);          printf("\n");
-      //}
+           //printf("threshold:        "); print256_as16_dec(threshold);        printf("\n");
+           //printf("R_factor:        "); print256_as16_dec(R_factor);        printf("\n");
+      }
 
       // 1. Calculation of the hit peak time and ADC
       __m256i is_sample_over_adc_peak = _mm256_cmpgt_epi16(RS, hit_peak_adc);
@@ -265,9 +266,11 @@ process_window_standard_rs_avx2(ProcessingInfo<NREGISTERS>& info)
 
         _mm256_storeu_si256(output_loc++, timenow); // NOLINT(runtime/increment_decrement)
         // STORE_MASK(hit_charge);
-        _mm256_storeu_si256(output_loc++, // NOLINT(runtime/increment_decrement)
-                            _mm256_blendv_epi8(_mm256_set1_epi16(0), hit_charge, left));
-        _mm256_storeu_si256(output_loc++, hit_tover); // NOLINT(runtime/increment_decrement)
+        //_mm256_storeu_si256(output_loc++, // NOLINT(runtime/increment_decrement)
+        //                    _mm256_blendv_epi8(_mm256_set1_epi16(0), hit_charge, left));
+        _mm256_storeu_si256(output_loc++, hit_charge);
+
+	_mm256_storeu_si256(output_loc++, hit_tover); // NOLINT(runtime/increment_decrement)
 
         _mm256_storeu_si256(output_loc++, hit_peak_adc); // NOLINT(runtime/increment_decrement)
 

--- a/include/fdreadoutlibs/wibeth/tpg/ProcessStandardRSAVX2.hpp
+++ b/include/fdreadoutlibs/wibeth/tpg/ProcessStandardRSAVX2.hpp
@@ -195,7 +195,7 @@ process_window_standard_rs_avx2(ProcessingInfo<NREGISTERS>& info)
       hit_charge = _mm256_min_epi16(hit_charge, overflowMax);
 
 
-      if(ireg==0){
+      //if(ireg==0){
       //     printf("itime=%ld\n", itime);
       //     printf("s:             "); print256_as16_dec(s);             printf("\n");
       //     printf("median:        "); print256_as16_dec(median);        printf("\n");
@@ -209,7 +209,7 @@ process_window_standard_rs_avx2(ProcessingInfo<NREGISTERS>& info)
       //     printf("left:          "); print256_as16_dec(left);          printf("\n");
       //     printf("threshold:        "); print256_as16_dec(threshold);        printf("\n");
       //     printf("R_factor:        "); print256_as16_dec(R_factor);        printf("\n");
-      }
+      //}
 
       // 1. Calculation of the hit peak time and ADC
       __m256i is_sample_over_adc_peak = _mm256_cmpgt_epi16(RS, hit_peak_adc);

--- a/include/fdreadoutlibs/wibeth/tpg/ProcessingInfo.hpp
+++ b/include/fdreadoutlibs/wibeth/tpg/ProcessingInfo.hpp
@@ -170,6 +170,7 @@ struct ProcessingInfo
       chanState.hit_charge[j] = 0;
 
       chanState.pedestalsRS[j] = 0;
+      chanState.accumRS[j] = 0;
       chanState.RS[j] = 0;
       // AAA: Quantiles are set to the pedestal value +/- 20 so that the IQR 
       // becomes above the RMS value of the input ADCs. We use the frugal 


### PR DESCRIPTION
The goal of this branch is to apply proper division by 10 in the NAIVE implementation of the TPG algorithms in order to emulate and match the AVX2 behaviour. This is achieved by adding a method `naive_avx2_div` (by Alex) and calling that in the NAIVE version of the algorithms. 

In addition a few other changes have been added. 
- `ProcessNaiveStandardRS.hpp` is the NAIVE counterpart of `ProcessStandardRSAVX2.hpp` 
- The running sum accumulator value for the 2nd pedestal subtraction is set to 0 similar to the frugal pedestal subtraction accumulator value.

These changes mostly do not affect the DAQ online running system. The changes have been tested using runs recorded in June with the ProtoDUNE-II HD setup.  