### PR TITLE
Change Order of SRS Operations.

### DIFF
--- a/include/fdreadoutlibs/wibeth/tpg/ProcessNaiveStandardRS.hpp
+++ b/include/fdreadoutlibs/wibeth/tpg/ProcessNaiveStandardRS.hpp
@@ -87,8 +87,8 @@ process_window_naive_StandardRS(ProcessingInfo<NREGISTERS>& info)
       // Naive: RS = (R * RS) + sample
       // RS = RS * RS_memory_factor + sample;
 
-      int16_t first_part = (int16_t)(RS * RS_memory_factor);
-      first_part = naive_avx2_div(first_part, (int16_t)10);
+      int16_t first_part = naive_avx2_div(first_part, (int16_t)10);
+      first_part = (int16_t)(RS * RS_memory_factor);
 
       int16_t second_part = sample;
       RS = (int16_t)(first_part + second_part);

--- a/include/fdreadoutlibs/wibeth/tpg/ProcessStandardRSAVX2.hpp
+++ b/include/fdreadoutlibs/wibeth/tpg/ProcessStandardRSAVX2.hpp
@@ -126,10 +126,10 @@ process_window_standard_rs_avx2(ProcessingInfo<NREGISTERS>& info)
       
       // Naive: RS = (R_factor * RS) + sample; 
 
-      // Instead of using floats in the calcualation of the RS we multiply by 10 and 
-      // do operations on the integers. In the end we divide by 10. 
+      // Instead of using floats in the calculation of the RS, we first divide by 10
+      // then multiply by R_factor. This order is to reduce cases of overflow.
 
-     __m256i first_part = swtpg_wibeth::_mm256_div_epi16(_mm256_mullo_epi16(RS, R_factor), 10);
+     __m256i first_part = _mm256_mullo_epi16(swtpg_wibeth::_mm256_div_epi16(RS, 10), R_factor);
 
      RS = _mm256_add_epi16(first_part, s);
 


### PR DESCRIPTION
This is to be consistent with the changes from #199 on AbsRS. The StandardRS implementations now also use the divide then multiply order of operations.

The decision to use this order was to reduce the frequency of overflows and the resulting misrepresented TPs. The downside is the loss in 1s digit precision from the ongoing running sum.