### PR TITLE
Add TPG Channel Masking

### DIFF
--- a/include/fdreadoutlibs/wibeth/WIBEthFrameProcessor.hpp
+++ b/include/fdreadoutlibs/wibeth/WIBEthFrameProcessor.hpp
@@ -30,6 +30,7 @@
 
 #include "tpglibs/TPGenerator.hpp"
 
+#include <algorithm>
 #include <atomic>
 #include <bitset>
 #include <functional>
@@ -119,7 +120,6 @@ private:
   std::unique_ptr<tpglibs::TPGenerator> m_tp_generator;
   std::vector<std::pair<std::string, nlohmann::json>> m_tpg_configs;
   uint32_t m_tp_max_width;
-  std::vector<unsigned int> m_channel_mask_vec;
   std::set<unsigned int> m_channel_mask_set;
   uint16_t m_tpg_threshold_selected;
 

--- a/src/wibeth/WIBEthFrameProcessor.cpp
+++ b/src/wibeth/WIBEthFrameProcessor.cpp
@@ -111,10 +111,7 @@ WIBEthFrameProcessor::conf(const appmodel::DataHandlerModule* conf)
 
       //m_tp_max_width = proc_conf->get_max_ticks_tot();
 
-      m_channel_mask_vec = proc_conf->get_channel_mask();
-      // Converting the input vector of channels masks into an std::set
-      // AAA: The set provides faster look up than a std::vector
-      m_channel_mask_set.insert(m_channel_mask_vec.begin(), m_channel_mask_vec.end());
+      const std::vector<unsigned int> channel_mask_vec = proc_conf->get_channel_mask();
 
       std::vector<const appmodel::ProcessingStep*> processing_steps = proc_conf->get_processing_steps();
       for (auto step : processing_steps) {
@@ -127,6 +124,11 @@ WIBEthFrameProcessor::conf(const appmodel::DataHandlerModule* conf)
         int16_t off_channel = m_channel_map->get_offline_channel_from_crate_slot_stream_chan(m_crate_id, m_slot_id, m_stream_id, chan);
         int16_t plane = m_channel_map->get_plane_from_offline_channel(off_channel);
         m_channel_plane_numbers.push_back(std::make_pair(off_channel, plane));
+
+        // This processor only needs to handle some (maybe 0) of the masked channels.
+        // Only get those relevant channels for the later check.
+        if (std::find(channel_mask_vec.begin(), channel_mask_vec.end(), off_channel) != channel_mask_vec.end())
+          m_channel_mask_set.insert(off_channel);
       }
 
       m_tp_generator->configure(m_tpg_configs, m_channel_plane_numbers, types::DUNEWIBEthTypeAdapter::samples_tick_difference);
@@ -335,6 +337,9 @@ WIBEthFrameProcessor::find_hits(constframeptr fp)
   std::vector<trgdataformats::TriggerPrimitive> tps = (*m_tp_generator)(wfptr);
 
   for (auto tp : tps) {
+    // If this TP is on a masked channel, skip it.
+    if (std::binary_search(m_channel_mask_set.begin(), m_channel_mask_set.end(), tp.channel))
+      continue;
     // Need to move into a type adapter.
     trigger::TriggerPrimitiveTypeAdapter tpa;
     tpa.tp = tp;


### PR DESCRIPTION
This adds a check to produced TPs to see if the channel was masked in configuration. If the channel is masked, then the TP stops here and doesn't continue.

This was run on a test session and confirming there were no TPs produce on the masked channels. I masked out large blocks of channels to increase confidence and to span multiple streams.