### PR TITLE
Use A Special TPG Algorithm Classifier.

### DIFF
--- a/include/fdreadoutlibs/TPGAlgorithmClassifier.hpp
+++ b/include/fdreadoutlibs/TPGAlgorithmClassifier.hpp
@@ -1,0 +1,61 @@
+/**
+ * This class is a hack to match configured TPG processing steps to the legacy, defined
+ * algorithms.
+ */
+
+#ifndef FDREADOUTLIBS_INCLUDE_FDREADOUTLIBS_TPGALGORITHMCLASSIFIER_HPP_
+#define FDREADOUTLIBS_INCLUDE_FDREADOUTLIBS_TPGALGORITHMCLASSIFIER_HPP_
+
+#include "trgdataformats/TriggerPrimitive.hpp"
+
+#include <unordered_map>
+#include <vector>
+
+namespace dunedaq {
+namespace fdreadoutlibs {
+
+class TPGAlgorithmClassifier {
+  std::vector<int> m_step_order{};
+  const std::unordered_map<std::string, int> m_tp_alg_id_map = {
+    {"AVXFrugalPedestalSubtractProcessor", 1},
+    {"AVXAbsRunSumProcessor", 2},
+    {"AVXRunSumProcessor", 3},
+    {"AVXThresholdProcessor", 4}
+  };
+
+  public:
+    /**
+     * @brief Take the processing step name and append the int value to m_step_order.
+     */
+    void
+    append_processing_step(const std::string& step_name) {
+      auto search = m_tp_alg_id_map.find(step_name);
+      if (search != m_tp_alg_id_map.end())
+        m_step_order.push_back(search->second);
+    }
+
+    /**
+     * @brief Check against the defined algorithms if these steps match.
+     */
+    trgdataformats::TriggerPrimitive::Algorithm
+    get_tpg_algorithm() {
+      const std::vector<int> abs_rs_order = {1, 2, 1, 4}; // Order that defines kAbsRunningSum.
+      const std::vector<int> rs_order = {1, 3, 1, 4}; // Order that defines kRunningSum.
+      const std::vector<int> st_order = {1, 4}; // Order that defines kSimpleThreshold.
+
+      if (m_step_order == abs_rs_order)
+        return trgdataformats::TriggerPrimitive::Algorithm::kAbsRunningSum;
+      if (m_step_order == rs_order)
+        return trgdataformats::TriggerPrimitive::Algorithm::kRunningSum;
+      if (m_step_order == st_order)
+        return trgdataformats::TriggerPrimitive::Algorithm::kSimpleThreshold;
+
+      // If it is none of the above, then it is unknown.
+      return trgdataformats::TriggerPrimitive::Algorithm::kUnknown;
+    }
+  };
+
+} // namespace fdreadoutlibs
+} // namespace dunedaq
+
+#endif // FDREADOUTLIBS_INCLUDE_FDREADOUTLIBS_TPGALGORITHMCLASSIFIER_HPP_

--- a/include/fdreadoutlibs/wibeth/WIBEthFrameProcessor.hpp
+++ b/include/fdreadoutlibs/wibeth/WIBEthFrameProcessor.hpp
@@ -9,6 +9,7 @@
 #define FDREADOUTLIBS_INCLUDE_FDREADOUTLIBS_WIBEth_WIBFRAMEPROCESSOR_HPP_
 
 #include "fdreadoutlibs/DUNEWIBEthTypeAdapter.hpp"
+#include "fdreadoutlibs/TPGAlgorithmClassifier.hpp"
 
 // #include "appfwk/DAQModuleHelper.hpp"
 #include "iomanager/IOManager.hpp"

--- a/src/wibeth/WIBEthFrameProcessor.cpp
+++ b/src/wibeth/WIBEthFrameProcessor.cpp
@@ -113,11 +113,20 @@ WIBEthFrameProcessor::conf(const appmodel::DataHandlerModule* conf)
       //m_tp_max_width = proc_conf->get_max_ticks_tot();
 
       const std::vector<unsigned int> channel_mask_vec = proc_conf->get_channel_mask();
+      TPGAlgorithmClassifier tpg_algo_classifier;
 
       std::vector<const appmodel::ProcessingStep*> processing_steps = proc_conf->get_processing_steps();
       for (auto step : processing_steps) {
         m_tpg_configs.push_back(std::make_pair(step->class_name(), step->to_json(false).back()));
+
+        // FIXME: Given that TPG is completely modular and nothing enforces an exact order, tracking the
+        // algorithm is difficult and hardly seems worth it since the configuration should express this.
+        //
+        // Need to find the algorithm.
+        tpg_algo_classifier.append_processing_step(step->class_name());
       }
+
+      m_tp_algo = tpg_algo_classifier.get_tpg_algorithm();
 
       // Setup post-processing pipeline
       m_channel_map = dunedaq::detchannelmaps::make_map(proc_conf->get_channel_map());
@@ -344,7 +353,9 @@ WIBEthFrameProcessor::find_hits(constframeptr fp)
     // Need to move into a type adapter.
     trigger::TriggerPrimitiveTypeAdapter tpa;
     tpa.tp = tp;
+
     tpa.tp.detid = m_det_id;  // Last missing piece.
+    tpa.tp.algorithm = m_tp_algo;
     m_tp_channel_rate_map[tp.channel]++;
     if(!m_tp_sink[m_channel_map->get_plane_from_offline_channel(tp.channel)]->try_send(std::move(tpa), iomanager::Sender::s_no_block)) {
       ers::warning(FailedToSendTP(ERS_HERE, tp.time_start, tp.channel));


### PR DESCRIPTION
I've added a new class whose only function is to interpret the TPG processing steps, their order, and return the algorithm that matches. However, `tpglibs` has made the algorithms for TPG modular and likely difficult to keep track of, so the matching is very limited to the algorithms that were used in v4.

This was tested in local sessions by varying the processing steps and checking the resultant algorithms with
```python
from trgtools import TPReader
tpr = TPReader(<filename>)
tpr.read_all_fragments()
print(tpr['algorithm'])
```