### PR TITLE
Added a condition that the previous timestamp is non-zero before checking whether there are missing frames

### DIFF
--- a/src/wibeth/WIBEthFrameProcessor.cpp
+++ b/src/wibeth/WIBEthFrameProcessor.cpp
@@ -294,7 +294,8 @@ WIBEthFrameProcessor::timestamp_check(frameptr fp)
   m_current_ts = wfptr->get_timestamp();
 
   // Check timestamp
-  if (m_current_ts - m_previous_ts != wibeth_frame_tick_difference) {
+  if (m_previous_ts > 0 &&
+      m_current_ts - m_previous_ts != wibeth_frame_tick_difference) {
     ++m_ts_error_ctr;
     m_error_registry->add_error("MISSING_FRAMES", datahandlinglibs::FrameErrorRegistry::ErrorInterval(m_previous_ts + wibeth_frame_tick_difference, m_current_ts));
     if (m_first_ts_missmatch) { // log once


### PR DESCRIPTION
...in the WIBEthFrameProcessor::timestamp_check() method.

We believe that the existing logic was inappropriately labeling the initial data at the start of each run as having MISSING_FRAMES.  This had the side effect of causing the BinarySearchQueueModel::lower_bound() method to be called instead of the FixedRateQueueModel::lower_bound() method, and that tickle some unexpected behavior in the BSQM.

