### PR TITLE
New unit tests for testing lower_bound() and request handling behavior on FD readout types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,7 @@ daq_add_application(wibeth_test_bench wibeth_test_bench.cxx TEST LINK_LIBRARIES 
 daq_add_unit_test(DAPHNEStreamSuperChunkTypeAdapter_test LINK_LIBRARIES fdreadoutlibs)
 daq_add_unit_test(WIBEthFrameExpansion_test LINK_LIBRARIES fdreadoutlibs)
 daq_add_unit_test(FDTypeAdaptersBuffers_test LINK_LIBRARIES fdreadoutlibs)
+daq_add_unit_test(FDReadoutRequestHandlers_test LINK_LIBRARIES fdreadoutlibs)
 
 ##############################################################################
 # Installation

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,7 @@ daq_add_application(wibeth_test_bench wibeth_test_bench.cxx TEST LINK_LIBRARIES 
 
 daq_add_unit_test(DAPHNEStreamSuperChunkTypeAdapter_test LINK_LIBRARIES fdreadoutlibs)
 daq_add_unit_test(WIBEthFrameExpansion_test LINK_LIBRARIES fdreadoutlibs)
+daq_add_unit_test(FDTypeAdaptersBuffers_test LINK_LIBRARIES fdreadoutlibs)
 
 ##############################################################################
 # Installation

--- a/include/fdreadoutlibs/DAPHNEStreamSuperChunkTypeAdapter.hpp
+++ b/include/fdreadoutlibs/DAPHNEStreamSuperChunkTypeAdapter.hpp
@@ -14,7 +14,7 @@ namespace dunedaq::fdreadoutlibs::types {
    * 12[DAPHNE frames] x 472[Bytes] = 5664[Bytes]                                                                           
    * */
   const constexpr std::size_t kDAPHNEStreamNumFrames = 12;
-  const constexpr std::size_t kDAPHNEStreamFrameSize = 472;
+  const constexpr std::size_t kDAPHNEStreamFrameSize = sizeof(dunedaq::fddetdataformats::DAPHNEStreamFrame);
   const constexpr std::size_t kDAPHNEStreamSuperChunkSize = kDAPHNEStreamNumFrames * kDAPHNEStreamFrameSize; // for 12: 5664 
 
   struct DAPHNEStreamSuperChunkTypeAdapter {

--- a/include/fdreadoutlibs/DAPHNESuperChunkTypeAdapter.hpp
+++ b/include/fdreadoutlibs/DAPHNESuperChunkTypeAdapter.hpp
@@ -19,8 +19,8 @@ namespace types {
  * @brief For DAPHNE the numbers are different.
  * 12[DAPHNE frames] x 454[32-bit words] x 4[Bytes per word] = 21792[Bytes]
  * */
-const constexpr std::size_t kDAPHNENumFrames = 12;
-const constexpr std::size_t kDAPHNEFrameSize = 1816;
+const constexpr std::size_t kDAPHNENumFrames = 3;
+const constexpr std::size_t kDAPHNEFrameSize = sizeof(dunedaq::fddetdataformats::DAPHNEFrame);
 const constexpr std::size_t kDAPHNESuperChunkSize = kDAPHNENumFrames * kDAPHNEFrameSize; // for 12: 21792
 struct DAPHNESuperChunkTypeAdapter
 {
@@ -47,10 +47,10 @@ struct DAPHNESuperChunkTypeAdapter
     frame->daq_header.timestamp_2 = ts >> 32;
   }
 
-  void fake_timestamps(uint64_t first_timestamp, uint64_t offset = 25) // NOLINT(build/unsigned)
+  void fake_timestamps(uint64_t first_timestamp, uint64_t offset = expected_tick_difference) // NOLINT(build/unsigned)
   {
     uint64_t ts_next = first_timestamp; // NOLINT(build/unsigned)
-    for (unsigned int i = 0; i < 12; ++i) {
+    for (unsigned int i = 0; i < get_num_frames(); ++i) {
       auto df = reinterpret_cast<dunedaq::fddetdataformats::DAPHNEFrame*>(((uint8_t*)(&data)) + i * get_frame_size()); // NOLINT
       df->daq_header.timestamp_1 = ts_next;
       df->daq_header.timestamp_2 = ts_next >> 32;
@@ -93,7 +93,7 @@ struct DAPHNESuperChunkTypeAdapter
 
   static const constexpr daqdataformats::SourceID::Subsystem subsystem = daqdataformats::SourceID::Subsystem::kDetectorReadout;
   static const constexpr daqdataformats::FragmentType fragment_type = daqdataformats::FragmentType::kDAPHNE;
-  static const constexpr uint64_t expected_tick_difference = 16; // NOLINT(build/unsigned)
+  static const constexpr uint64_t expected_tick_difference = 1024; // NOLINT(build/unsigned)
 };
 
 static_assert(sizeof(struct DAPHNESuperChunkTypeAdapter) == kDAPHNESuperChunkSize,

--- a/include/fdreadoutlibs/DUNEWIBEthTypeAdapter.hpp
+++ b/include/fdreadoutlibs/DUNEWIBEthTypeAdapter.hpp
@@ -44,7 +44,7 @@ struct DUNEWIBEthTypeAdapter
     frame->set_timestamp(ts);
   }
 
-  void fake_timestamps(uint64_t first_timestamp, uint64_t /*offset = 2048*/ ) // NOLINT(build/unsigned)
+  void fake_timestamps(uint64_t first_timestamp, uint64_t /*offset*/= 2048 ) // NOLINT(build/unsigned)
   {
     auto wef = reinterpret_cast<FrameType*>(((uint8_t*)(&data))); // NOLINT
     wef->set_timestamp(first_timestamp);

--- a/include/fdreadoutlibs/TDEEthTypeAdapter.hpp
+++ b/include/fdreadoutlibs/TDEEthTypeAdapter.hpp
@@ -45,7 +45,7 @@ struct TDEEthTypeAdapter
     frame->set_timestamp(ts);
   }
 
-  void fake_timestamps(uint64_t first_timestamp, uint64_t /*offset = 2048*/ ) // NOLINT(build/unsigned)
+  void fake_timestamps(uint64_t first_timestamp, uint64_t /*offset*/ = 2048 ) // NOLINT(build/unsigned)
   {
     auto wef = reinterpret_cast<FrameType*>(((uint8_t*)(&data))); // NOLINT
     wef->set_timestamp(first_timestamp);

--- a/unittest/FDReadoutRequestHandlers_test.cxx
+++ b/unittest/FDReadoutRequestHandlers_test.cxx
@@ -11,6 +11,7 @@
 #include "fdreadoutlibs/DUNEWIBEthTypeAdapter.hpp"
 #include "fdreadoutlibs/DAPHNEStreamSuperChunkTypeAdapter.hpp"
 #include "fdreadoutlibs/DAPHNESuperChunkTypeAdapter.hpp"
+#include "fdreadoutlibs/TDEEthTypeAdapter.hpp"
 
 #include "datahandlinglibs/testutils/TestUtilities.hpp"
 
@@ -60,6 +61,20 @@ BOOST_AUTO_TEST_CASE(SkipListLatencyBufferModel_DAPHNESuperChunk)
     dunedaq::datahandlinglibs::test::test_request_model<
             dunedaq::datahandlinglibs::SkipListLatencyBufferModel,
             dunedaq::fdreadoutlibs::types::DAPHNESuperChunkTypeAdapter>();
+}
+
+BOOST_AUTO_TEST_CASE(FixedRateQueueModel_TDEEth)
+{
+    dunedaq::datahandlinglibs::test::test_request_model<
+            dunedaq::datahandlinglibs::FixedRateQueueModel,
+            dunedaq::fdreadoutlibs::types::TDEEthTypeAdapter>();
+}
+
+BOOST_AUTO_TEST_CASE(BinarySearchQueueModel_TDEEth)
+{
+    dunedaq::datahandlinglibs::test::test_request_model<
+            dunedaq::datahandlinglibs::BinarySearchQueueModel,
+            dunedaq::fdreadoutlibs::types::TDEEthTypeAdapter>();
 }
 
 

--- a/unittest/FDReadoutRequestHandlers_test.cxx
+++ b/unittest/FDReadoutRequestHandlers_test.cxx
@@ -22,6 +22,7 @@
 #include "boost/test/unit_test.hpp"
 
 #include <iostream>
+#include <cmath>
 #include <sstream>
 #include <set>
 #include <iterator>
@@ -89,12 +90,67 @@ public:
 template <template<class> class BufferType, class TypeAdapter>
 void test_request_model()
 {
-    using DefaultRequestHandler = TestDefaultRequestHandlerModel<TypeAdapter, BufferType<TypeAdapter> >;
+
+  using DefaultRequestHandler = TestDefaultRequestHandlerModel<TypeAdapter, BufferType<TypeAdapter> >;
 
   //some testing vars
   TypeAdapter test_element;
-  uint64_t ticks_between = TypeAdapter::expected_tick_difference*test_element.get_num_frames();
+  uint64_t n_frames = test_element.get_num_frames();
+  uint64_t ticks_per_frame = TypeAdapter::expected_tick_difference;
+  uint64_t ticks_between = ticks_per_frame*n_frames;
 
+
+  //
+  auto test_req_bounds = [&](std::shared_ptr<BufferType<TypeAdapter>> buffer,
+                             uint64_t start_win, uint64_t end_win,
+                             bool check_exact){
+
+      //make the error registry we need
+      auto errorRegistry = std::make_unique<dunedaq::datahandlinglibs::FrameErrorRegistry>();
+
+      //create the request handler
+      DefaultRequestHandler requestHandler(buffer,errorRegistry);
+
+      //call the get_fragment_pieces
+      auto dfmessage = dunedaq::dfmessages::DataRequest();
+      auto req_res = typename DefaultRequestHandler::RequestResult(DefaultRequestHandler::ResultCode::kUnknown,dfmessage);
+      auto ret = requestHandler.get_fragment_pieces(start_win,end_win,req_res);
+
+      //check that the return code is correct.
+      BOOST_CHECK_EQUAL(req_res.result_code,DefaultRequestHandler::ResultCode::kFound);
+
+      //check that the first and last returned blocks are note empty
+      BOOST_CHECK_GT(ret.front().second,0);
+      BOOST_CHECK_GT(ret.back().second,0);
+
+      //grab the (first) timestamps of the first and last frames
+      uint64_t first_ts = reinterpret_cast<const TypeAdapter::FrameType*>(ret.front().first)->get_timestamp();
+      uint64_t last_ts = reinterpret_cast<const TypeAdapter::FrameType*>((char*)(ret.back().first)+(ret.back().second)-sizeof(typename TypeAdapter::FrameType))->get_timestamp();
+
+      //general check:
+      // first_ts <= start_win < first_ts + ticks_per_frame
+      // last_ts < end_win <= last_ts + ticks_per_frame
+      BOOST_CHECK_MESSAGE((first_ts<=start_win && start_win<(first_ts+TypeAdapter::expected_tick_difference)),
+                          "Check first_frame_ts{" << first_ts << "} <= start_win{"
+                          << start_win << "} < first_frame_ts+ticks_per_frame{" << first_ts+TypeAdapter::expected_tick_difference << "}");
+      BOOST_CHECK_MESSAGE((last_ts<end_win && end_win<=(last_ts+TypeAdapter::expected_tick_difference)),
+                          "Check last_frame_ts{" << last_ts << "} < end_win{"
+                          << end_win << "} < last_frame_ts+ticks_per_frame{" << last_ts+TypeAdapter::expected_tick_difference << "}");
+
+      if(check_exact) {
+          auto expected_start = TypeAdapter::expected_tick_difference *
+                                (uint64_t) std::floor((float) (start_win) / (float) (ticks_per_frame));
+          auto expected_end = TypeAdapter::expected_tick_difference *
+                              (uint64_t) std::ceil((float) (end_win) / (float) (ticks_per_frame));
+
+          //specfic check: are values for this request what we expect
+          BOOST_CHECK_MESSAGE(first_ts == expected_start,
+                              "Fragment start ts {" << first_ts << "} is expected value {" << expected_start << "}");
+          BOOST_CHECK_MESSAGE((last_ts + TypeAdapter::expected_tick_difference) == expected_end,
+                              "Fragment 'end' ts {" << last_ts + TypeAdapter::expected_tick_difference
+                                                    << "} is expected value {" << expected_end << "}");
+      }
+  };
 
   /*
    * Unskipped buffer should have elements with index [0, 1 , 2 , 3 , 4 , 5 , 6 , 7 , 8 , 9 ]
@@ -106,71 +162,64 @@ void test_request_model()
   fill_buffer<BufferType,TypeAdapter>(buffer_noskip,0,10);
   print_buffer<BufferType,TypeAdapter>(buffer_noskip,"noskip");
 
-  //make the error registry we need
-  auto errorRegistry_noskip = std::make_unique<dunedaq::datahandlinglibs::FrameErrorRegistry>();
+  test_req_bounds(buffer_noskip,ticks_between*2,ticks_between*5,true);
+  test_req_bounds(buffer_noskip,ticks_between*3/2,ticks_between*9/2,true);
+  test_req_bounds(buffer_noskip,ticks_between*2+1,ticks_between*5+1,true);
 
-  //create the request handler
-  DefaultRequestHandler requestHandler(buffer_noskip,errorRegistry_noskip);
+  /*
+   * Skipped buffer should have elements with index [0, 1 , 2 , 3 , 4 , 5 , 6 , 7 ,  8 ,  9 ]
+   *                                 and timestamps [0,1*T,2*T,5*T,6*T,7*T,8*T,9*T,10*T,11*T]
+   * where T = DTS ticks between successive elements (tick_diff_per_frame * n_frames_per_obj_in_buffer)
+  */
+  /*
+  BOOST_TEST_MESSAGE("Testing buffer with skips...");
+  std::set<size_t> obj_to_skip = {2,3};
+  auto buffer_skip = std::make_shared< BufferType<TypeAdapter> >();
+  fill_buffer<BufferType,TypeAdapter>(buffer_skip,0,10,obj_to_skip);
+  print_buffer<BufferType,TypeAdapter>(buffer_skip,"skip");
 
-  //
-  auto test_req_bounds = [&](uint64_t start_win, uint64_t end_win,
-                             uint64_t expected_start, uint64_t expected_end){
-
-      auto dfmessage = dunedaq::dfmessages::DataRequest();
-      auto req_res = typename DefaultRequestHandler::RequestResult(DefaultRequestHandler::ResultCode::kUnknown,dfmessage);
-      auto ret = requestHandler.get_fragment_pieces(start_win,end_win,req_res);
-
-      //check that the return code is correct.
-      BOOST_CHECK_EQUAL(req_res.result_code,DefaultRequestHandler::ResultCode::kFound);
-
-      //grab the (first) timestamps of the first and last frames
-      uint64_t first_ts = reinterpret_cast<const TypeAdapter::FrameType*>(ret.front().first)->get_timestamp();
-      uint64_t last_ts = reinterpret_cast<const TypeAdapter::FrameType*>((char*)(ret.back().first)+(ret.back().second)-sizeof(typename TypeAdapter::FrameType))->get_timestamp();
-
-      //general check:
-      // first_ts <= start_win < first_ts + ticks_per_frame
-      // last_ts < end_win <= last_ts + ticks_per_frame
-      BOOST_CHECK_LE(first_ts,start_win);
-      BOOST_CHECK_GT(first_ts+TypeAdapter::expected_tick_difference,start_win);
-
-      BOOST_CHECK_GE(last_ts+TypeAdapter::expected_tick_difference,end_win);
-      BOOST_CHECK_LT(last_ts,end_win);
-
-      //specfic check: are values for this request what we expect
-      BOOST_CHECK_EQUAL(first_ts,expected_start);
-      BOOST_CHECK_EQUAL(last_ts+TypeAdapter::expected_tick_difference,expected_end);
-  };
-  test_req_bounds(ticks_between*2,ticks_between*5,ticks_between*2,ticks_between*5);
-  test_req_bounds(ticks_between*3/2,ticks_between*9/2,ticks_between,ticks_between*5);
-
+    test_req_bounds(ticks_between*2,ticks_between*5,false);
+    test_req_bounds(ticks_between*3/2,ticks_between*9/2,false);
+    test_req_bounds(ticks_between*2+1,ticks_between*5+1,false);
+*/
 }
 
 BOOST_AUTO_TEST_SUITE(FDReadoutRequestHandlers_test)
 
 BOOST_AUTO_TEST_CASE(FixedRateQueueModel_DUNEWIBEth)
 {
-  test_request_model<
-          dunedaq::datahandlinglibs::FixedRateQueueModel,
-          dunedaq::fdreadoutlibs::types::DUNEWIBEthTypeAdapter>();
+    test_request_model<
+            dunedaq::datahandlinglibs::FixedRateQueueModel,
+            dunedaq::fdreadoutlibs::types::DUNEWIBEthTypeAdapter>();
 }
-/*
+
 BOOST_AUTO_TEST_CASE(BinarySearchQueueModel_DUNEWIBEth)
 {
-  test_queue_model<dunedaq::datahandlinglibs::BinarySearchQueueModel,dunedaq::fdreadoutlibs::types::DUNEWIBEthTypeAdapter>();
+    test_request_model<
+            dunedaq::datahandlinglibs::BinarySearchQueueModel,
+            dunedaq::fdreadoutlibs::types::DUNEWIBEthTypeAdapter>();
 }
 BOOST_AUTO_TEST_CASE(FixedRateQueueModel_DAPHNEStreamSuperChunk)
 {
-  test_queue_model<dunedaq::datahandlinglibs::FixedRateQueueModel,dunedaq::fdreadoutlibs::types::DAPHNEStreamSuperChunkTypeAdapter>();
+    test_request_model<
+            dunedaq::datahandlinglibs::FixedRateQueueModel,
+            dunedaq::fdreadoutlibs::types::DAPHNEStreamSuperChunkTypeAdapter>();
 }
+
 BOOST_AUTO_TEST_CASE(BinarySearchQueueModel_DAPHNEStreamSuperChunk)
 {
-  test_queue_model<dunedaq::datahandlinglibs::BinarySearchQueueModel,dunedaq::fdreadoutlibs::types::DAPHNEStreamSuperChunkTypeAdapter>();
+    test_request_model<
+            dunedaq::datahandlinglibs::BinarySearchQueueModel,
+            dunedaq::fdreadoutlibs::types::DAPHNEStreamSuperChunkTypeAdapter>();
 }
+
 BOOST_AUTO_TEST_CASE(SkipListLatencyBufferModel_DAPHNESuperChunk)
 {
-  test_queue_model<dunedaq::datahandlinglibs::SkipListLatencyBufferModel,dunedaq::fdreadoutlibs::types::DAPHNESuperChunkTypeAdapter>();
+    test_request_model<
+            dunedaq::datahandlinglibs::SkipListLatencyBufferModel,
+            dunedaq::fdreadoutlibs::types::DAPHNESuperChunkTypeAdapter>();
 }
-*/
+
 
 BOOST_AUTO_TEST_SUITE_END()
 

--- a/unittest/FDReadoutRequestHandlers_test.cxx
+++ b/unittest/FDReadoutRequestHandlers_test.cxx
@@ -12,12 +12,11 @@
 #include "fdreadoutlibs/DAPHNEStreamSuperChunkTypeAdapter.hpp"
 #include "fdreadoutlibs/DAPHNESuperChunkTypeAdapter.hpp"
 
+#include "datahandlinglibs/testutils/TestUtilities.hpp"
+
 #include "datahandlinglibs/models/FixedRateQueueModel.hpp"
 #include "datahandlinglibs/models/BinarySearchQueueModel.hpp"
 #include "datahandlinglibs/models/SkipListLatencyBufferModel.hpp"
-
-#include "datahandlinglibs/models/DefaultRequestHandlerModel.hpp"
-#include "datahandlinglibs/FrameErrorRegistry.hpp"
 
 #include "boost/test/unit_test.hpp"
 
@@ -27,213 +26,38 @@
 #include <set>
 #include <iterator>
 
-//general test buffer struct that can be reused
-template <template<class> class BufferType, class TypeAdapter>
-void fill_buffer( std::shared_ptr< BufferType<TypeAdapter> >& buffer,
-		  uint64_t const init_timestamp=0,
-		  size_t const n_obj=10,
-		  std::set<size_t> const obj_to_skip = {})
-{
-  //allocate mem in buffer
-  buffer->allocate_memory(n_obj);
-  
-  //some accounting
-  size_t i=0,i_obj=0;
-  uint64_t next_timestamp=init_timestamp;
-  
-  //while we want to add to the buffer
-  while(i_obj<n_obj){
-    
-    //create a frame with appropriate timestamp
-    TypeAdapter frame;
-    frame.fake_timestamps(next_timestamp);
-    
-    //increment to the next timestamp
-    next_timestamp += uint64_t(frame.get_num_frames()*TypeAdapter::expected_tick_difference);
-    
-    //only write in buffer if not in the skip list
-    if(obj_to_skip.count(i)==0) {
-      buffer->write(std::move(frame));
-      ++i_obj;
-    }
-    ++i;
-    
-    
-  } // end while(obj_in_buffer<n_obj)
-}
-
-template <template<class> class BufferType, class TypeAdapter>
-void print_buffer(std::shared_ptr<BufferType<TypeAdapter>>& buffer, std::string desc)
-{
-  std::stringstream ss;
-  ss << "Buffer (" << desc << "): ";
-  typename BufferType<TypeAdapter>::Iterator iter=buffer->begin();
-  while(iter!=buffer->end()){
-    ss << iter->get_timestamp() << " ";
-    ++iter;
-  }
-  BOOST_TEST_MESSAGE(ss.str());
-
-}
-
-template<class ReadoutType, class LatencyBufferType>
-class TestDefaultRequestHandlerModel : public dunedaq::datahandlinglibs::DefaultRequestHandlerModel<ReadoutType, LatencyBufferType>
-{
-public:
-    TestDefaultRequestHandlerModel(std::shared_ptr<LatencyBufferType>& latency_buffer,
-                                   std::unique_ptr<dunedaq::datahandlinglibs::FrameErrorRegistry>& error_registry)
-          : dunedaq::datahandlinglibs::DefaultRequestHandlerModel<ReadoutType, LatencyBufferType>(latency_buffer,error_registry) {}
-    using dunedaq::datahandlinglibs::DefaultRequestHandlerModel<ReadoutType, LatencyBufferType>::get_fragment_pieces;
-};
-
-
-template <template<class> class BufferType, class TypeAdapter>
-void test_request_model()
-{
-
-  using DefaultRequestHandler = TestDefaultRequestHandlerModel<TypeAdapter, BufferType<TypeAdapter> >;
-
-  //some testing vars
-  TypeAdapter test_element;
-  uint64_t n_frames = test_element.get_num_frames();
-  uint64_t ticks_per_frame = TypeAdapter::expected_tick_difference;
-  uint64_t ticks_between = ticks_per_frame*n_frames;
-
-
-  // function for testing get_fragment_pieces in cases where there are no skips in the buffer
-  auto test_req_bounds = [&](std::shared_ptr<BufferType<TypeAdapter>> buffer,
-                             uint64_t start_win, uint64_t end_win,
-                             std::set<size_t> objects_skipped={}){
-
-      //make the error registry we need
-      auto errorRegistry = std::make_unique<dunedaq::datahandlinglibs::FrameErrorRegistry>();
-
-      //create the request handler
-      DefaultRequestHandler requestHandler(buffer,errorRegistry);
-
-      //call the get_fragment_pieces
-      auto dfmessage = dunedaq::dfmessages::DataRequest();
-      auto req_res = typename DefaultRequestHandler::RequestResult(DefaultRequestHandler::ResultCode::kUnknown,dfmessage);
-      auto ret = requestHandler.get_fragment_pieces(start_win,end_win,req_res);
-
-      //check that the return code is correct.
-      BOOST_CHECK_EQUAL(req_res.result_code,DefaultRequestHandler::ResultCode::kFound);
-
-      //check that the first and last returned blocks are note empty
-      BOOST_REQUIRE_GT(ret.front().second,0);
-      BOOST_REQUIRE_GT(ret.back().second,0);
-
-      //grab the (first) timestamps of the first and last frames
-      uint64_t first_ts = reinterpret_cast<const TypeAdapter::FrameType*>(ret.front().first)->get_timestamp();
-      uint64_t last_ts = reinterpret_cast<const TypeAdapter::FrameType*>((char*)(ret.back().first)+(ret.back().second)-sizeof(typename TypeAdapter::FrameType))->get_timestamp();
-
-      //general check:
-      // first_ts <= start_win < first_ts + ticks_per_frame
-      // last_ts < end_win <= last_ts + ticks_per_frame
-      if(objects_skipped.size()==0)
-          BOOST_CHECK_MESSAGE(first_ts<=start_win,
-                              "first_frame_ts{" << first_ts << "} <= start_win{" << start_win << "}");
-      BOOST_CHECK_MESSAGE(start_win<first_ts+ticks_per_frame,
-                          "start_win{" << start_win << "} < first_frame_ts+ticks_per_frame{" << first_ts+ticks_per_frame << "}");
-      BOOST_CHECK_MESSAGE(last_ts<end_win,
-                          "Check last_frame_ts{" << last_ts << "} < end_win{" << end_win << "}");
-      if(objects_skipped.size()==0)
-          BOOST_CHECK_MESSAGE(end_win<=last_ts+ticks_per_frame,
-                              "end_win{" << end_win << "} <= last_frame_ts+ticks_per_frame{" << last_ts+ticks_per_frame << "}");
-
-      //expected timestamps for begin of fragment and 'end' of fragment, assuming no skipping
-      auto expected_start = TypeAdapter::expected_tick_difference *
-              (uint64_t) std::floor((float) (start_win) / (float) (ticks_per_frame));
-      auto expected_end = TypeAdapter::expected_tick_difference *
-              (uint64_t) std::ceil((float) (end_win) / (float) (ticks_per_frame));
-
-      //correct for the cases there that object has been skipped
-      auto expected_start_obj = expected_start - expected_start%ticks_between;
-      while(objects_skipped.count(expected_start_obj/ticks_between)>0) {
-          expected_start += ticks_per_frame;
-          expected_start_obj = expected_start - expected_start%ticks_between;
-      }
-
-      auto expected_end_obj = expected_end - ticks_per_frame - (expected_end-ticks_per_frame)%ticks_between;
-      while(objects_skipped.count(expected_end_obj/ticks_between)>0) {
-          expected_end -= ticks_per_frame;
-          expected_start_obj = expected_end - ticks_per_frame - (expected_end-ticks_per_frame)%ticks_between;
-      }
-
-      //specfic check: are values for this request what we expect
-      BOOST_CHECK_MESSAGE(first_ts == expected_start,
-                          "Fragment start ts {" << first_ts << "} is expected value {" << expected_start << "}");
-      BOOST_CHECK_MESSAGE((last_ts + TypeAdapter::expected_tick_difference) == expected_end,
-                          "Fragment 'end' ts {" << last_ts + TypeAdapter::expected_tick_difference
-                          << "} is expected value {" << expected_end << "}");
-  };
-
-  /*
-   * Unskipped buffer should have elements with index [0, 1 , 2 , 3 , 4 , 5 , 6 , 7 , 8 , 9 ]
-   *                                   and timestamps [0,1*T,2*T,3*T,4*T,5*T,6*T,7*T,8*T,9*T]
-   * where T = DTS ticks between successive elements (tick_diff_per_frame * n_frames_per_obj_in_buffer)
-   */
-  BOOST_TEST_MESSAGE("Testing buffer without skips...");
-  auto buffer_noskip = std::make_shared< BufferType<TypeAdapter> >();
-  fill_buffer<BufferType,TypeAdapter>(buffer_noskip,0,10);
-  print_buffer<BufferType,TypeAdapter>(buffer_noskip,"noskip");
-
-  test_req_bounds(buffer_noskip,ticks_between*2,ticks_between*5);
-  test_req_bounds(buffer_noskip,ticks_between*3/2,ticks_between*9/2);
-  test_req_bounds(buffer_noskip,ticks_between*11/5,ticks_between*21/5);
-  test_req_bounds(buffer_noskip,ticks_between*2+1,ticks_between*5+1);
-
-  /*
-   * Skipped buffer should have elements with index [0, 1 , 2 , 3 , 4 , 5 , 6 , 7 ,  8 ,  9 ]
-   *                                 and timestamps [0,1*T,2*T,5*T,6*T,7*T,8*T,9*T,10*T,11*T]
-   * where T = DTS ticks between successive elements (tick_diff_per_frame * n_frames_per_obj_in_buffer)
-  */
-
-  BOOST_TEST_MESSAGE("Testing buffer with skips...");
-  std::set<size_t> obj_to_skip = {2,3};
-  auto buffer_skip = std::make_shared< BufferType<TypeAdapter> >();
-  fill_buffer<BufferType,TypeAdapter>(buffer_skip,0,10,obj_to_skip);
-  print_buffer<BufferType,TypeAdapter>(buffer_skip,"skip");
-
-  test_req_bounds(buffer_skip,ticks_between*2,ticks_between*5,obj_to_skip);
-  test_req_bounds(buffer_skip,ticks_between*3/2,ticks_between*9/2,obj_to_skip);
-  test_req_bounds(buffer_skip,ticks_between*11/5,ticks_between*21/5,obj_to_skip);
-  test_req_bounds(buffer_skip,ticks_between*2+1,ticks_between*5+1,obj_to_skip);
-
-}
-
 BOOST_AUTO_TEST_SUITE(FDReadoutRequestHandlers_test)
 
 BOOST_AUTO_TEST_CASE(FixedRateQueueModel_DUNEWIBEth)
 {
-    test_request_model<
+    dunedaq::datahandlinglibs::test::test_request_model<
             dunedaq::datahandlinglibs::FixedRateQueueModel,
             dunedaq::fdreadoutlibs::types::DUNEWIBEthTypeAdapter>();
 }
 
 BOOST_AUTO_TEST_CASE(BinarySearchQueueModel_DUNEWIBEth)
 {
-    test_request_model<
+    dunedaq::datahandlinglibs::test::test_request_model<
             dunedaq::datahandlinglibs::BinarySearchQueueModel,
             dunedaq::fdreadoutlibs::types::DUNEWIBEthTypeAdapter>();
 }
 BOOST_AUTO_TEST_CASE(FixedRateQueueModel_DAPHNEStreamSuperChunk)
 {
-    test_request_model<
+    dunedaq::datahandlinglibs::test::test_request_model<
             dunedaq::datahandlinglibs::FixedRateQueueModel,
             dunedaq::fdreadoutlibs::types::DAPHNEStreamSuperChunkTypeAdapter>();
 }
 
 BOOST_AUTO_TEST_CASE(BinarySearchQueueModel_DAPHNEStreamSuperChunk)
 {
-    test_request_model<
+    dunedaq::datahandlinglibs::test::test_request_model<
             dunedaq::datahandlinglibs::BinarySearchQueueModel,
             dunedaq::fdreadoutlibs::types::DAPHNEStreamSuperChunkTypeAdapter>();
 }
 
 BOOST_AUTO_TEST_CASE(SkipListLatencyBufferModel_DAPHNESuperChunk)
 {
-    test_request_model<
+    dunedaq::datahandlinglibs::test::test_request_model<
             dunedaq::datahandlinglibs::SkipListLatencyBufferModel,
             dunedaq::fdreadoutlibs::types::DAPHNESuperChunkTypeAdapter>();
 }

--- a/unittest/FDReadoutRequestHandlers_test.cxx
+++ b/unittest/FDReadoutRequestHandlers_test.cxx
@@ -1,0 +1,177 @@
+/**
+ * @file FDReadoutRequestHandlers_test.cxx  Unittest for expanding the WIBEth frames
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2022.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#define BOOST_TEST_MODULE FDReadoutRequestHandlers_test // NOLINT
+
+#include "fdreadoutlibs/DUNEWIBEthTypeAdapter.hpp"
+#include "fdreadoutlibs/DAPHNEStreamSuperChunkTypeAdapter.hpp"
+#include "fdreadoutlibs/DAPHNESuperChunkTypeAdapter.hpp"
+
+#include "datahandlinglibs/models/FixedRateQueueModel.hpp"
+#include "datahandlinglibs/models/BinarySearchQueueModel.hpp"
+#include "datahandlinglibs/models/SkipListLatencyBufferModel.hpp"
+
+#include "datahandlinglibs/models/DefaultRequestHandlerModel.hpp"
+#include "datahandlinglibs/FrameErrorRegistry.hpp"
+
+#include "boost/test/unit_test.hpp"
+
+#include <iostream>
+#include <sstream>
+#include <set>
+#include <iterator>
+
+//general test buffer struct that can be reused
+template <template<class> class BufferType, class TypeAdapter>
+void fill_buffer( std::shared_ptr< BufferType<TypeAdapter> >& buffer,
+		  uint64_t const init_timestamp=0,
+		  size_t const n_obj=10,
+		  std::set<size_t> const obj_to_skip = {})
+{
+  //allocate mem in buffer
+  buffer->allocate_memory(n_obj);
+  
+  //some accounting
+  size_t i=0,i_obj=0;
+  uint64_t next_timestamp=init_timestamp;
+  
+  //while we want to add to the buffer
+  while(i_obj<n_obj){
+    
+    //create a frame with appropriate timestamp
+    TypeAdapter frame;
+    frame.fake_timestamps(next_timestamp);
+    
+    //increment to the next timestamp
+    next_timestamp += uint64_t(frame.get_num_frames()*TypeAdapter::expected_tick_difference);
+    
+    //only write in buffer if not in the skip list
+    if(obj_to_skip.count(i)==0) {
+      buffer->write(std::move(frame));
+      ++i_obj;
+    }
+    ++i;
+    
+    
+  } // end while(obj_in_buffer<n_obj)
+}
+
+template <template<class> class BufferType, class TypeAdapter>
+void print_buffer(std::shared_ptr<BufferType<TypeAdapter>>& buffer, std::string desc)
+{
+  std::stringstream ss;
+  ss << "Buffer (" << desc << "): ";
+  typename BufferType<TypeAdapter>::Iterator iter=buffer->begin();
+  while(iter!=buffer->end()){
+    ss << iter->get_timestamp() << " ";
+    ++iter;
+  }
+  BOOST_TEST_MESSAGE(ss.str());
+
+}
+
+template<class ReadoutType, class LatencyBufferType>
+class TestDefaultRequestHandlerModel : public dunedaq::datahandlinglibs::DefaultRequestHandlerModel<ReadoutType, LatencyBufferType>
+{
+public:
+    TestDefaultRequestHandlerModel(std::shared_ptr<LatencyBufferType>& latency_buffer,
+                                   std::unique_ptr<dunedaq::datahandlinglibs::FrameErrorRegistry>& error_registry)
+          : dunedaq::datahandlinglibs::DefaultRequestHandlerModel<ReadoutType, LatencyBufferType>(latency_buffer,error_registry) {}
+    using dunedaq::datahandlinglibs::DefaultRequestHandlerModel<ReadoutType, LatencyBufferType>::get_fragment_pieces;
+};
+
+
+template <template<class> class BufferType, class TypeAdapter>
+void test_request_model()
+{
+    using DefaultRequestHandler = TestDefaultRequestHandlerModel<TypeAdapter, BufferType<TypeAdapter> >;
+
+  //some testing vars
+  TypeAdapter test_element;
+  uint64_t ticks_between = TypeAdapter::expected_tick_difference*test_element.get_num_frames();
+
+
+  /*
+   * Unskipped buffer should have elements with index [0, 1 , 2 , 3 , 4 , 5 , 6 , 7 , 8 , 9 ]
+   *                                   and timestamps [0,1*T,2*T,3*T,4*T,5*T,6*T,7*T,8*T,9*T]
+   * where T = DTS ticks between successive elements (tick_diff_per_frame * n_frames_per_obj_in_buffer)
+   */
+  BOOST_TEST_MESSAGE("Testing buffer without skips...");
+  auto buffer_noskip = std::make_shared< BufferType<TypeAdapter> >();
+  fill_buffer<BufferType,TypeAdapter>(buffer_noskip,0,10);
+  print_buffer<BufferType,TypeAdapter>(buffer_noskip,"noskip");
+
+  //make the error registry we need
+  auto errorRegistry_noskip = std::make_unique<dunedaq::datahandlinglibs::FrameErrorRegistry>();
+
+  //create the request handler
+  DefaultRequestHandler requestHandler(buffer_noskip,errorRegistry_noskip);
+
+  //
+  auto test_req_bounds = [&](uint64_t start_win, uint64_t end_win,
+                             uint64_t expected_start, uint64_t expected_end){
+
+      auto dfmessage = dunedaq::dfmessages::DataRequest();
+      auto req_res = typename DefaultRequestHandler::RequestResult(DefaultRequestHandler::ResultCode::kUnknown,dfmessage);
+      auto ret = requestHandler.get_fragment_pieces(start_win,end_win,req_res);
+
+      //check that the return code is correct.
+      BOOST_CHECK_EQUAL(req_res.result_code,DefaultRequestHandler::ResultCode::kFound);
+
+      //grab the (first) timestamps of the first and last frames
+      uint64_t first_ts = reinterpret_cast<const TypeAdapter::FrameType*>(ret.front().first)->get_timestamp();
+      uint64_t last_ts = reinterpret_cast<const TypeAdapter::FrameType*>((char*)(ret.back().first)+(ret.back().second)-sizeof(typename TypeAdapter::FrameType))->get_timestamp();
+
+      //general check:
+      // first_ts <= start_win < first_ts + ticks_per_frame
+      // last_ts < end_win <= last_ts + ticks_per_frame
+      BOOST_CHECK_LE(first_ts,start_win);
+      BOOST_CHECK_GT(first_ts+TypeAdapter::expected_tick_difference,start_win);
+
+      BOOST_CHECK_GE(last_ts+TypeAdapter::expected_tick_difference,end_win);
+      BOOST_CHECK_LT(last_ts,end_win);
+
+      //specfic check: are values for this request what we expect
+      BOOST_CHECK_EQUAL(first_ts,expected_start);
+      BOOST_CHECK_EQUAL(last_ts+TypeAdapter::expected_tick_difference,expected_end);
+  };
+  test_req_bounds(ticks_between*2,ticks_between*5,ticks_between*2,ticks_between*5);
+  test_req_bounds(ticks_between*3/2,ticks_between*9/2,ticks_between,ticks_between*5);
+
+}
+
+BOOST_AUTO_TEST_SUITE(FDReadoutRequestHandlers_test)
+
+BOOST_AUTO_TEST_CASE(FixedRateQueueModel_DUNEWIBEth)
+{
+  test_request_model<
+          dunedaq::datahandlinglibs::FixedRateQueueModel,
+          dunedaq::fdreadoutlibs::types::DUNEWIBEthTypeAdapter>();
+}
+/*
+BOOST_AUTO_TEST_CASE(BinarySearchQueueModel_DUNEWIBEth)
+{
+  test_queue_model<dunedaq::datahandlinglibs::BinarySearchQueueModel,dunedaq::fdreadoutlibs::types::DUNEWIBEthTypeAdapter>();
+}
+BOOST_AUTO_TEST_CASE(FixedRateQueueModel_DAPHNEStreamSuperChunk)
+{
+  test_queue_model<dunedaq::datahandlinglibs::FixedRateQueueModel,dunedaq::fdreadoutlibs::types::DAPHNEStreamSuperChunkTypeAdapter>();
+}
+BOOST_AUTO_TEST_CASE(BinarySearchQueueModel_DAPHNEStreamSuperChunk)
+{
+  test_queue_model<dunedaq::datahandlinglibs::BinarySearchQueueModel,dunedaq::fdreadoutlibs::types::DAPHNEStreamSuperChunkTypeAdapter>();
+}
+BOOST_AUTO_TEST_CASE(SkipListLatencyBufferModel_DAPHNESuperChunk)
+{
+  test_queue_model<dunedaq::datahandlinglibs::SkipListLatencyBufferModel,dunedaq::fdreadoutlibs::types::DAPHNESuperChunkTypeAdapter>();
+}
+*/
+
+BOOST_AUTO_TEST_SUITE_END()
+
+

--- a/unittest/FDReadoutRequestHandlers_test.cxx
+++ b/unittest/FDReadoutRequestHandlers_test.cxx
@@ -100,10 +100,10 @@ void test_request_model()
   uint64_t ticks_between = ticks_per_frame*n_frames;
 
 
-  //
+  // function for testing get_fragment_pieces in cases where there are no skips in the buffer
   auto test_req_bounds = [&](std::shared_ptr<BufferType<TypeAdapter>> buffer,
                              uint64_t start_win, uint64_t end_win,
-                             bool check_exact){
+                             std::set<size_t> objects_skipped={}){
 
       //make the error registry we need
       auto errorRegistry = std::make_unique<dunedaq::datahandlinglibs::FrameErrorRegistry>();
@@ -120,8 +120,8 @@ void test_request_model()
       BOOST_CHECK_EQUAL(req_res.result_code,DefaultRequestHandler::ResultCode::kFound);
 
       //check that the first and last returned blocks are note empty
-      BOOST_CHECK_GT(ret.front().second,0);
-      BOOST_CHECK_GT(ret.back().second,0);
+      BOOST_REQUIRE_GT(ret.front().second,0);
+      BOOST_REQUIRE_GT(ret.back().second,0);
 
       //grab the (first) timestamps of the first and last frames
       uint64_t first_ts = reinterpret_cast<const TypeAdapter::FrameType*>(ret.front().first)->get_timestamp();
@@ -130,26 +130,42 @@ void test_request_model()
       //general check:
       // first_ts <= start_win < first_ts + ticks_per_frame
       // last_ts < end_win <= last_ts + ticks_per_frame
-      BOOST_CHECK_MESSAGE((first_ts<=start_win && start_win<(first_ts+TypeAdapter::expected_tick_difference)),
-                          "Check first_frame_ts{" << first_ts << "} <= start_win{"
-                          << start_win << "} < first_frame_ts+ticks_per_frame{" << first_ts+TypeAdapter::expected_tick_difference << "}");
-      BOOST_CHECK_MESSAGE((last_ts<end_win && end_win<=(last_ts+TypeAdapter::expected_tick_difference)),
-                          "Check last_frame_ts{" << last_ts << "} < end_win{"
-                          << end_win << "} < last_frame_ts+ticks_per_frame{" << last_ts+TypeAdapter::expected_tick_difference << "}");
+      if(objects_skipped.size()==0)
+          BOOST_CHECK_MESSAGE(first_ts<=start_win,
+                              "first_frame_ts{" << first_ts << "} <= start_win{" << start_win << "}");
+      BOOST_CHECK_MESSAGE(start_win<first_ts+ticks_per_frame,
+                          "start_win{" << start_win << "} < first_frame_ts+ticks_per_frame{" << first_ts+ticks_per_frame << "}");
+      BOOST_CHECK_MESSAGE(last_ts<end_win,
+                          "Check last_frame_ts{" << last_ts << "} < end_win{" << end_win << "}");
+      if(objects_skipped.size()==0)
+          BOOST_CHECK_MESSAGE(end_win<=last_ts+ticks_per_frame,
+                              "end_win{" << end_win << "} <= last_frame_ts+ticks_per_frame{" << last_ts+ticks_per_frame << "}");
 
-      if(check_exact) {
-          auto expected_start = TypeAdapter::expected_tick_difference *
-                                (uint64_t) std::floor((float) (start_win) / (float) (ticks_per_frame));
-          auto expected_end = TypeAdapter::expected_tick_difference *
-                              (uint64_t) std::ceil((float) (end_win) / (float) (ticks_per_frame));
+      //expected timestamps for begin of fragment and 'end' of fragment, assuming no skipping
+      auto expected_start = TypeAdapter::expected_tick_difference *
+              (uint64_t) std::floor((float) (start_win) / (float) (ticks_per_frame));
+      auto expected_end = TypeAdapter::expected_tick_difference *
+              (uint64_t) std::ceil((float) (end_win) / (float) (ticks_per_frame));
 
-          //specfic check: are values for this request what we expect
-          BOOST_CHECK_MESSAGE(first_ts == expected_start,
-                              "Fragment start ts {" << first_ts << "} is expected value {" << expected_start << "}");
-          BOOST_CHECK_MESSAGE((last_ts + TypeAdapter::expected_tick_difference) == expected_end,
-                              "Fragment 'end' ts {" << last_ts + TypeAdapter::expected_tick_difference
-                                                    << "} is expected value {" << expected_end << "}");
+      //correct for the cases there that object has been skipped
+      auto expected_start_obj = expected_start - expected_start%ticks_between;
+      while(objects_skipped.count(expected_start_obj/ticks_between)>0) {
+          expected_start += ticks_per_frame;
+          expected_start_obj = expected_start - expected_start%ticks_between;
       }
+
+      auto expected_end_obj = expected_end - ticks_per_frame - (expected_end-ticks_per_frame)%ticks_between;
+      while(objects_skipped.count(expected_end_obj/ticks_between)>0) {
+          expected_end -= ticks_per_frame;
+          expected_start_obj = expected_end - ticks_per_frame - (expected_end-ticks_per_frame)%ticks_between;
+      }
+
+      //specfic check: are values for this request what we expect
+      BOOST_CHECK_MESSAGE(first_ts == expected_start,
+                          "Fragment start ts {" << first_ts << "} is expected value {" << expected_start << "}");
+      BOOST_CHECK_MESSAGE((last_ts + TypeAdapter::expected_tick_difference) == expected_end,
+                          "Fragment 'end' ts {" << last_ts + TypeAdapter::expected_tick_difference
+                          << "} is expected value {" << expected_end << "}");
   };
 
   /*
@@ -162,26 +178,28 @@ void test_request_model()
   fill_buffer<BufferType,TypeAdapter>(buffer_noskip,0,10);
   print_buffer<BufferType,TypeAdapter>(buffer_noskip,"noskip");
 
-  test_req_bounds(buffer_noskip,ticks_between*2,ticks_between*5,true);
-  test_req_bounds(buffer_noskip,ticks_between*3/2,ticks_between*9/2,true);
-  test_req_bounds(buffer_noskip,ticks_between*2+1,ticks_between*5+1,true);
+  test_req_bounds(buffer_noskip,ticks_between*2,ticks_between*5);
+  test_req_bounds(buffer_noskip,ticks_between*3/2,ticks_between*9/2);
+  test_req_bounds(buffer_noskip,ticks_between*11/5,ticks_between*21/5);
+  test_req_bounds(buffer_noskip,ticks_between*2+1,ticks_between*5+1);
 
   /*
    * Skipped buffer should have elements with index [0, 1 , 2 , 3 , 4 , 5 , 6 , 7 ,  8 ,  9 ]
    *                                 and timestamps [0,1*T,2*T,5*T,6*T,7*T,8*T,9*T,10*T,11*T]
    * where T = DTS ticks between successive elements (tick_diff_per_frame * n_frames_per_obj_in_buffer)
   */
-  /*
+
   BOOST_TEST_MESSAGE("Testing buffer with skips...");
   std::set<size_t> obj_to_skip = {2,3};
   auto buffer_skip = std::make_shared< BufferType<TypeAdapter> >();
   fill_buffer<BufferType,TypeAdapter>(buffer_skip,0,10,obj_to_skip);
   print_buffer<BufferType,TypeAdapter>(buffer_skip,"skip");
 
-    test_req_bounds(ticks_between*2,ticks_between*5,false);
-    test_req_bounds(ticks_between*3/2,ticks_between*9/2,false);
-    test_req_bounds(ticks_between*2+1,ticks_between*5+1,false);
-*/
+  test_req_bounds(buffer_skip,ticks_between*2,ticks_between*5,obj_to_skip);
+  test_req_bounds(buffer_skip,ticks_between*3/2,ticks_between*9/2,obj_to_skip);
+  test_req_bounds(buffer_skip,ticks_between*11/5,ticks_between*21/5,obj_to_skip);
+  test_req_bounds(buffer_skip,ticks_between*2+1,ticks_between*5+1,obj_to_skip);
+
 }
 
 BOOST_AUTO_TEST_SUITE(FDReadoutRequestHandlers_test)

--- a/unittest/FDTypeAdaptersBuffers_test.cxx
+++ b/unittest/FDTypeAdaptersBuffers_test.cxx
@@ -121,7 +121,11 @@ void test_queue_model()
   TypeAdapter test_element;
   uint64_t ticks_between = TypeAdapter::expected_tick_difference*test_element.get_num_frames();
 
-
+  /*
+   * Unskipped buffer should have elements with index [0, 1 , 2 , 3 , 4 , 5 , 6 , 7 , 8 , 9 ]
+   *                                   and timestamps [0,1*T,2*T,3*T,4*T,5*T,6*T,7*T,8*T,9*T]
+   * where T = DTS ticks between successive elements (tick_diff_per_frame * n_frames_per_obj_in_buffer)
+   */
   BOOST_TEST_MESSAGE("Testing buffer without skips...");
   fill_buffer(buffer_noskip,0,10);
   print_buffer(buffer_noskip,"noskip");
@@ -135,8 +139,13 @@ void test_queue_model()
   test_lower_bound<BufferType,TypeAdapter>(buffer_noskip,ticks_between*5/2,3);
   
   // get lower bound when minimally unaligned, next instance
-  test_lower_bound<BufferType,TypeAdapter>(buffer_noskip,ticks_between+1,2);  
+  test_lower_bound<BufferType,TypeAdapter>(buffer_noskip,ticks_between+1,2);
 
+  /*
+   * Skipped buffer should have elements with index [0, 1 , 2 , 3 , 4 , 5 , 6 , 7 ,  8 ,  9 ]
+   *                                 and timestamps [0,1*T,2*T,5*T,6*T,7*T,8*T,9*T,10*T,11*T]
+   * where T = DTS ticks between successive elements (tick_diff_per_frame * n_frames_per_obj_in_buffer)
+  */
   BOOST_TEST_MESSAGE("Testing buffer with skips...");
   std::set<size_t> obj_to_skip = {2,3};
   fill_buffer(buffer_skip,0,10,obj_to_skip);
@@ -152,9 +161,12 @@ void test_queue_model()
   // should return next available
   test_lower_bound<BufferType,TypeAdapter>(buffer_skip,ticks_between*3/2,2,true);
   test_lower_bound<BufferType,TypeAdapter>(buffer_skip,ticks_between*5/2,2,true);
+  test_lower_bound<BufferType,TypeAdapter>(buffer_skip,ticks_between*7/2,2,true);
   // should be unaffected
   test_lower_bound<BufferType,TypeAdapter>(buffer_skip,ticks_between*1/2,1,true);
-  
+  test_lower_bound<BufferType,TypeAdapter>(buffer_skip,ticks_between*9/2,3,true);
+  test_lower_bound<BufferType,TypeAdapter>(buffer_skip,ticks_between*11/2,4,true);
+
   // get lower bound when minimally unaligned, next instance
   test_lower_bound<BufferType,TypeAdapter>(buffer_skip,ticks_between+1,2,true);  
   test_lower_bound<BufferType,TypeAdapter>(buffer_skip,ticks_between*2+1,2,true);  

--- a/unittest/FDTypeAdaptersBuffers_test.cxx
+++ b/unittest/FDTypeAdaptersBuffers_test.cxx
@@ -11,6 +11,7 @@
 #include "fdreadoutlibs/DUNEWIBEthTypeAdapter.hpp"
 #include "fdreadoutlibs/DAPHNEStreamSuperChunkTypeAdapter.hpp"
 #include "fdreadoutlibs/DAPHNESuperChunkTypeAdapter.hpp"
+#include "fdreadoutlibs/TDEEthTypeAdapter.hpp"
 
 #include "datahandlinglibs/testutils/TestUtilities.hpp"
 
@@ -47,6 +48,14 @@ BOOST_AUTO_TEST_CASE(BinarySearchQueueModel_DAPHNEStreamSuperChunk)
 BOOST_AUTO_TEST_CASE(SkipListLatencyBufferModel_DAPHNESuperChunk)
 {
     dunedaq::datahandlinglibs::test::test_queue_model<dunedaq::datahandlinglibs::SkipListLatencyBufferModel,dunedaq::fdreadoutlibs::types::DAPHNESuperChunkTypeAdapter>();
+}
+BOOST_AUTO_TEST_CASE(FixedRateQueueModel_TDEEth)
+{
+    dunedaq::datahandlinglibs::test::test_queue_model<dunedaq::datahandlinglibs::FixedRateQueueModel,dunedaq::fdreadoutlibs::types::TDEEthTypeAdapter>();
+}
+BOOST_AUTO_TEST_CASE(BinarySearchQueueModel_TDEEth)
+{
+    dunedaq::datahandlinglibs::test::test_queue_model<dunedaq::datahandlinglibs::BinarySearchQueueModel,dunedaq::fdreadoutlibs::types::TDEEthTypeAdapter>();
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittest/FDTypeAdaptersBuffers_test.cxx
+++ b/unittest/FDTypeAdaptersBuffers_test.cxx
@@ -12,10 +12,11 @@
 #include "fdreadoutlibs/DAPHNEStreamSuperChunkTypeAdapter.hpp"
 #include "fdreadoutlibs/DAPHNESuperChunkTypeAdapter.hpp"
 
+#include "datahandlinglibs/testutils/TestUtilities.hpp"
+
 #include "datahandlinglibs/models/FixedRateQueueModel.hpp"
 #include "datahandlinglibs/models/BinarySearchQueueModel.hpp"
 #include "datahandlinglibs/models/SkipListLatencyBufferModel.hpp"
-#include "datahandlinglibs/concepts/LatencyBufferConcept.hpp"
 
 
 #include "boost/test/unit_test.hpp"
@@ -25,176 +26,27 @@
 #include <set>
 #include <iterator>
 
-//general test buffer struct that can be reused
-template <template<class> class BufferType, class TypeAdapter>
-void fill_buffer( BufferType<TypeAdapter>& buffer,
-		  uint64_t const init_timestamp=0,
-		  size_t const n_obj=10,
-		  std::set<size_t> const obj_to_skip = {})
-{
-  //allocate mem in buffer
-  buffer.allocate_memory(n_obj);
-  
-  //some accounting
-  size_t i=0,i_obj=0;
-  uint64_t next_timestamp=init_timestamp;
-  
-  //while we want to add to the buffer
-  while(i_obj<n_obj){
-    
-    //create a frame with appropriate timestamp
-    TypeAdapter frame;
-    frame.fake_timestamps(next_timestamp);
-    
-    //increment to the next timestamp
-    next_timestamp += uint64_t(frame.get_num_frames()*TypeAdapter::expected_tick_difference);
-    
-    //only write in buffer if not in the skip list
-    if(obj_to_skip.count(i)==0) {
-      buffer.write(std::move(frame));
-      ++i_obj;
-    }
-    ++i;
-    
-    
-  } // end while(obj_in_buffer<n_obj)
-}
-
-template <template<class> class BufferType, class TypeAdapter>
-void test_lower_bound( BufferType<TypeAdapter>& buffer,
-		       uint64_t test_ts,
-		       uint32_t expected_idx,
-		       bool with_errors=false)
-{
-  TypeAdapter test_element; test_element.set_timestamp(test_ts);
-  typename BufferType<TypeAdapter>::Iterator expected_el =  buffer.begin();
-  for(size_t i=0; i<expected_idx; ++i){
-    ++expected_el;
-  }
-
-  //get our lower_bound call
-  auto return_el = buffer.lower_bound(test_element,with_errors);
-
-  //loop through to get the previous element to return_el
-  typename BufferType<TypeAdapter>::Iterator scan_el =  buffer.begin();
-  typename BufferType<TypeAdapter>::Iterator prev_el =  buffer.begin();
-  while(scan_el!=return_el){
-    ++scan_el;
-    if(scan_el==return_el) break;
-    ++prev_el;
-  }
-  
-  //check that expected and return timestamps agree
-  BOOST_CHECK_MESSAGE(expected_el->get_timestamp()==return_el->get_timestamp(),
-		      "Expected ts{" << expected_el->get_timestamp() << "} == return ts{" << return_el->get_timestamp() << "} for test_ts=" << test_ts);
-  
-  //check that we satisfy the lower bound condition
-  BOOST_CHECK_MESSAGE(return_el->get_timestamp()>=test_ts,
-		      "Returned ts{" << return_el->get_timestamp() << "} is >= test_ts{" << test_ts << "}");
-  BOOST_CHECK_MESSAGE((prev_el->get_timestamp()<test_ts || return_el==buffer.begin()),
-		      "Prev ts{" << prev_el->get_timestamp() << "} is < test_ts{" << test_ts << "} (or lower bound is begin of buffer)");
-}
-
-template <template<class> class BufferType, class TypeAdapter>
-void print_buffer(BufferType<TypeAdapter>& buffer, std::string desc)
-{
-  std::stringstream ss;
-  ss << "Buffer (" << desc << "): ";
-  typename BufferType<TypeAdapter>::Iterator iter=buffer.begin();
-  while(iter!=buffer.end()){
-    ss << iter->get_timestamp() << " ";
-    ++iter;
-  }
-  BOOST_TEST_MESSAGE(ss.str());
-
-}
-
-
-template <template<class> class BufferType, class TypeAdapter>
-void test_queue_model()
-{
-
-  //create our buffer
-  BufferType<TypeAdapter> buffer_noskip,buffer_skip;
-
-  //some testing vars
-  TypeAdapter test_element;
-  uint64_t ticks_between = TypeAdapter::expected_tick_difference*test_element.get_num_frames();
-
-  /*
-   * Unskipped buffer should have elements with index [0, 1 , 2 , 3 , 4 , 5 , 6 , 7 , 8 , 9 ]
-   *                                   and timestamps [0,1*T,2*T,3*T,4*T,5*T,6*T,7*T,8*T,9*T]
-   * where T = DTS ticks between successive elements (tick_diff_per_frame * n_frames_per_obj_in_buffer)
-   */
-  BOOST_TEST_MESSAGE("Testing buffer without skips...");
-  fill_buffer(buffer_noskip,0,10);
-  print_buffer(buffer_noskip,"noskip");
-  
-  // get lower bound on aligned element
-  // should return the exact value
-  test_lower_bound<BufferType,TypeAdapter>(buffer_noskip,ticks_between*2,2);
-
-  // get lower bound when maximally unaligned
-  // should get the next element up
-  test_lower_bound<BufferType,TypeAdapter>(buffer_noskip,ticks_between*5/2,3);
-  
-  // get lower bound when minimally unaligned, next instance
-  test_lower_bound<BufferType,TypeAdapter>(buffer_noskip,ticks_between+1,2);
-
-  /*
-   * Skipped buffer should have elements with index [0, 1 , 2 , 3 , 4 , 5 , 6 , 7 ,  8 ,  9 ]
-   *                                 and timestamps [0,1*T,2*T,5*T,6*T,7*T,8*T,9*T,10*T,11*T]
-   * where T = DTS ticks between successive elements (tick_diff_per_frame * n_frames_per_obj_in_buffer)
-  */
-  BOOST_TEST_MESSAGE("Testing buffer with skips...");
-  std::set<size_t> obj_to_skip = {2,3};
-  fill_buffer(buffer_skip,0,10,obj_to_skip);
-  print_buffer(buffer_skip,"skip");
-
-  // get lower bound on aligned but skipped element
-  // should return next available
-  test_lower_bound<BufferType,TypeAdapter>(buffer_skip,ticks_between*2,2,true);
-  // should be unaffected
-  test_lower_bound<BufferType,TypeAdapter>(buffer_skip,ticks_between,1,true);
-
-  // get lower bound when maximally unaligned
-  // should return next available
-  test_lower_bound<BufferType,TypeAdapter>(buffer_skip,ticks_between*3/2,2,true);
-  test_lower_bound<BufferType,TypeAdapter>(buffer_skip,ticks_between*5/2,2,true);
-  test_lower_bound<BufferType,TypeAdapter>(buffer_skip,ticks_between*7/2,2,true);
-  // should be unaffected
-  test_lower_bound<BufferType,TypeAdapter>(buffer_skip,ticks_between*1/2,1,true);
-  test_lower_bound<BufferType,TypeAdapter>(buffer_skip,ticks_between*9/2,3,true);
-  test_lower_bound<BufferType,TypeAdapter>(buffer_skip,ticks_between*11/2,4,true);
-
-  // get lower bound when minimally unaligned, next instance
-  test_lower_bound<BufferType,TypeAdapter>(buffer_skip,ticks_between+1,2,true);  
-  test_lower_bound<BufferType,TypeAdapter>(buffer_skip,ticks_between*2+1,2,true);  
-  // should be unaffected
-  test_lower_bound<BufferType,TypeAdapter>(buffer_skip,1,1,true);
-}
-
 BOOST_AUTO_TEST_SUITE(FDReadoutTypeAdaptersBuffers_test)
 
 BOOST_AUTO_TEST_CASE(FixedRateQueueModel_DUNEWIBEth)
 {
-  test_queue_model<dunedaq::datahandlinglibs::FixedRateQueueModel,dunedaq::fdreadoutlibs::types::DUNEWIBEthTypeAdapter>();
+    dunedaq::datahandlinglibs::test::test_queue_model<dunedaq::datahandlinglibs::FixedRateQueueModel,dunedaq::fdreadoutlibs::types::DUNEWIBEthTypeAdapter>();
 }
 BOOST_AUTO_TEST_CASE(BinarySearchQueueModel_DUNEWIBEth)
 {
-  test_queue_model<dunedaq::datahandlinglibs::BinarySearchQueueModel,dunedaq::fdreadoutlibs::types::DUNEWIBEthTypeAdapter>();
+    dunedaq::datahandlinglibs::test::test_queue_model<dunedaq::datahandlinglibs::BinarySearchQueueModel,dunedaq::fdreadoutlibs::types::DUNEWIBEthTypeAdapter>();
 }
 BOOST_AUTO_TEST_CASE(FixedRateQueueModel_DAPHNEStreamSuperChunk)
 {
-  test_queue_model<dunedaq::datahandlinglibs::FixedRateQueueModel,dunedaq::fdreadoutlibs::types::DAPHNEStreamSuperChunkTypeAdapter>();
+    dunedaq::datahandlinglibs::test::test_queue_model<dunedaq::datahandlinglibs::FixedRateQueueModel,dunedaq::fdreadoutlibs::types::DAPHNEStreamSuperChunkTypeAdapter>();
 }
 BOOST_AUTO_TEST_CASE(BinarySearchQueueModel_DAPHNEStreamSuperChunk)
 {
-  test_queue_model<dunedaq::datahandlinglibs::BinarySearchQueueModel,dunedaq::fdreadoutlibs::types::DAPHNEStreamSuperChunkTypeAdapter>();
+    dunedaq::datahandlinglibs::test::test_queue_model<dunedaq::datahandlinglibs::BinarySearchQueueModel,dunedaq::fdreadoutlibs::types::DAPHNEStreamSuperChunkTypeAdapter>();
 }
 BOOST_AUTO_TEST_CASE(SkipListLatencyBufferModel_DAPHNESuperChunk)
 {
-  test_queue_model<dunedaq::datahandlinglibs::SkipListLatencyBufferModel,dunedaq::fdreadoutlibs::types::DAPHNESuperChunkTypeAdapter>();
+    dunedaq::datahandlinglibs::test::test_queue_model<dunedaq::datahandlinglibs::SkipListLatencyBufferModel,dunedaq::fdreadoutlibs::types::DAPHNESuperChunkTypeAdapter>();
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittest/FDTypeAdaptersBuffers_test.cxx
+++ b/unittest/FDTypeAdaptersBuffers_test.cxx
@@ -1,0 +1,190 @@
+/**
+ * @file FDTypeAdapters_test.cxx  Unittest for expanding the WIBEth frames
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2022.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#define BOOST_TEST_MODULE FDTypeAdaptersBuffers_test // NOLINT
+
+#include "fdreadoutlibs/DUNEWIBEthTypeAdapter.hpp"
+#include "fdreadoutlibs/DAPHNEStreamSuperChunkTypeAdapter.hpp"
+#include "fdreadoutlibs/DAPHNESuperChunkTypeAdapter.hpp"
+
+#include "datahandlinglibs/models/FixedRateQueueModel.hpp"
+#include "datahandlinglibs/models/BinarySearchQueueModel.hpp"
+#include "datahandlinglibs/models/SkipListLatencyBufferModel.hpp"
+#include "datahandlinglibs/concepts/LatencyBufferConcept.hpp"
+
+
+#include "boost/test/unit_test.hpp"
+
+#include <iostream>
+#include <sstream>
+#include <set>
+#include <iterator>
+
+//general test buffer struct that can be reused
+template <template<class> class BufferType, class TypeAdapter>
+void fill_buffer( BufferType<TypeAdapter>& buffer,
+		  uint64_t const init_timestamp=0,
+		  size_t const n_obj=10,
+		  std::set<size_t> const obj_to_skip = {})
+{
+  //allocate mem in buffer
+  buffer.allocate_memory(n_obj);
+  
+  //some accounting
+  size_t i=0,i_obj=0;
+  uint64_t next_timestamp=init_timestamp;
+  
+  //while we want to add to the buffer
+  while(i_obj<n_obj){
+    
+    //create a frame with appropriate timestamp
+    TypeAdapter frame;
+    frame.fake_timestamps(next_timestamp);
+    
+    //increment to the next timestamp
+    next_timestamp += uint64_t(frame.get_num_frames()*TypeAdapter::expected_tick_difference);
+    
+    //only write in buffer if not in the skip list
+    if(obj_to_skip.count(i)==0) {
+      buffer.write(std::move(frame));
+      ++i_obj;
+    }
+    ++i;
+    
+    
+  } // end while(obj_in_buffer<n_obj)
+}
+
+template <template<class> class BufferType, class TypeAdapter>
+void test_lower_bound( BufferType<TypeAdapter>& buffer,
+		       uint64_t test_ts,
+		       uint32_t expected_idx,
+		       bool with_errors=false)
+{
+  TypeAdapter test_element; test_element.set_timestamp(test_ts);
+  typename BufferType<TypeAdapter>::Iterator expected_el =  buffer.begin();
+  for(size_t i=0; i<expected_idx; ++i){
+    ++expected_el;
+  }
+
+  //get our lower_bound call
+  auto return_el = buffer.lower_bound(test_element,with_errors);
+
+  //loop through to get the previous element to return_el
+  typename BufferType<TypeAdapter>::Iterator scan_el =  buffer.begin();
+  typename BufferType<TypeAdapter>::Iterator prev_el =  buffer.begin();
+  while(scan_el!=return_el){
+    ++scan_el;
+    if(scan_el==return_el) break;
+    ++prev_el;
+  }
+  
+  //check that expected and return timestamps agree
+  BOOST_CHECK_MESSAGE(expected_el->get_timestamp()==return_el->get_timestamp(),
+		      "Expected ts{" << expected_el->get_timestamp() << "} == return ts{" << return_el->get_timestamp() << "} for test_ts=" << test_ts);
+  
+  //check that we satisfy the lower bound condition
+  BOOST_CHECK_MESSAGE(return_el->get_timestamp()>=test_ts,
+		      "Returned ts{" << return_el->get_timestamp() << "} is >= test_ts{" << test_ts << "}");
+  BOOST_CHECK_MESSAGE((prev_el->get_timestamp()<test_ts || return_el==buffer.begin()),
+		      "Prev ts{" << prev_el->get_timestamp() << "} is < test_ts{" << test_ts << "} (or lower bound is begin of buffer)");
+}
+
+template <template<class> class BufferType, class TypeAdapter>
+void print_buffer(BufferType<TypeAdapter>& buffer, std::string desc)
+{
+  std::stringstream ss;
+  ss << "Buffer (" << desc << "): ";
+  typename BufferType<TypeAdapter>::Iterator iter=buffer.begin();
+  while(iter!=buffer.end()){
+    ss << iter->get_timestamp() << " ";
+    ++iter;
+  }
+  BOOST_TEST_MESSAGE(ss.str());
+
+}
+
+
+template <template<class> class BufferType, class TypeAdapter>
+void test_queue_model()
+{
+
+  //create our buffer
+  BufferType<TypeAdapter> buffer_noskip,buffer_skip;
+
+  //some testing vars
+  TypeAdapter test_element;
+  uint64_t ticks_between = TypeAdapter::expected_tick_difference*test_element.get_num_frames();
+
+
+  BOOST_TEST_MESSAGE("Testing buffer without skips...");
+  fill_buffer(buffer_noskip,0,10);
+  print_buffer(buffer_noskip,"noskip");
+  
+  // get lower bound on aligned element
+  // should return the exact value
+  test_lower_bound<BufferType,TypeAdapter>(buffer_noskip,ticks_between*2,2);
+
+  // get lower bound when maximally unaligned
+  // should get the next element up
+  test_lower_bound<BufferType,TypeAdapter>(buffer_noskip,ticks_between*5/2,3);
+  
+  // get lower bound when minimally unaligned, next instance
+  test_lower_bound<BufferType,TypeAdapter>(buffer_noskip,ticks_between+1,2);  
+
+  BOOST_TEST_MESSAGE("Testing buffer with skips...");
+  std::set<size_t> obj_to_skip = {2,3};
+  fill_buffer(buffer_skip,0,10,obj_to_skip);
+  print_buffer(buffer_skip,"skip");
+
+  // get lower bound on aligned but skipped element
+  // should return next available
+  test_lower_bound<BufferType,TypeAdapter>(buffer_skip,ticks_between*2,2,true);
+  // should be unaffected
+  test_lower_bound<BufferType,TypeAdapter>(buffer_skip,ticks_between,1,true);
+
+  // get lower bound when maximally unaligned
+  // should return next available
+  test_lower_bound<BufferType,TypeAdapter>(buffer_skip,ticks_between*3/2,2,true);
+  test_lower_bound<BufferType,TypeAdapter>(buffer_skip,ticks_between*5/2,2,true);
+  // should be unaffected
+  test_lower_bound<BufferType,TypeAdapter>(buffer_skip,ticks_between*1/2,1,true);
+  
+  // get lower bound when minimally unaligned, next instance
+  test_lower_bound<BufferType,TypeAdapter>(buffer_skip,ticks_between+1,2,true);  
+  test_lower_bound<BufferType,TypeAdapter>(buffer_skip,ticks_between*2+1,2,true);  
+  // should be unaffected
+  test_lower_bound<BufferType,TypeAdapter>(buffer_skip,1,1,true);
+}
+
+BOOST_AUTO_TEST_SUITE(FDReadoutTypeAdaptersBuffers_test)
+
+BOOST_AUTO_TEST_CASE(FixedRateQueueModel_DUNEWIBEth)
+{
+  test_queue_model<dunedaq::datahandlinglibs::FixedRateQueueModel,dunedaq::fdreadoutlibs::types::DUNEWIBEthTypeAdapter>();
+}
+BOOST_AUTO_TEST_CASE(BinarySearchQueueModel_DUNEWIBEth)
+{
+  test_queue_model<dunedaq::datahandlinglibs::BinarySearchQueueModel,dunedaq::fdreadoutlibs::types::DUNEWIBEthTypeAdapter>();
+}
+BOOST_AUTO_TEST_CASE(FixedRateQueueModel_DAPHNEStreamSuperChunk)
+{
+  test_queue_model<dunedaq::datahandlinglibs::FixedRateQueueModel,dunedaq::fdreadoutlibs::types::DAPHNEStreamSuperChunkTypeAdapter>();
+}
+BOOST_AUTO_TEST_CASE(BinarySearchQueueModel_DAPHNEStreamSuperChunk)
+{
+  test_queue_model<dunedaq::datahandlinglibs::BinarySearchQueueModel,dunedaq::fdreadoutlibs::types::DAPHNEStreamSuperChunkTypeAdapter>();
+}
+BOOST_AUTO_TEST_CASE(SkipListLatencyBufferModel_DAPHNESuperChunk)
+{
+  test_queue_model<dunedaq::datahandlinglibs::SkipListLatencyBufferModel,dunedaq::fdreadoutlibs::types::DAPHNESuperChunkTypeAdapter>();
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+


### PR DESCRIPTION
Needs https://github.com/DUNE-DAQ/datahandlinglibs/pull/27

This adds a new unit test `unittest/FDTypeAdaptersBuffers_test.cxx` that tests lower_bound behavior across a variety of TypeAdapters and Buffers in use in FD readout.

I'm starting this as a draft PR to allow for some early review, while I work to prepare a second set of unit tests related to request handlers. 

To test, pull down the mentioned datahandlinglibs branch, and then can do
```
dbt-build --unittests fdreadoutlibs
```
