### PR TITLE
Ran clang format on FDReadoutRequestHandlers_test.cxx and FDTypeAdapt…

### DIFF
--- a/unittest/FDReadoutRequestHandlers_test.cxx
+++ b/unittest/FDReadoutRequestHandlers_test.cxx
@@ -8,76 +8,68 @@
 
 #define BOOST_TEST_MODULE FDReadoutRequestHandlers_test // NOLINT
 
-#include "fdreadoutlibs/DUNEWIBEthTypeAdapter.hpp"
 #include "fdreadoutlibs/DAPHNEStreamSuperChunkTypeAdapter.hpp"
 #include "fdreadoutlibs/DAPHNESuperChunkTypeAdapter.hpp"
+#include "fdreadoutlibs/DUNEWIBEthTypeAdapter.hpp"
 #include "fdreadoutlibs/TDEEthTypeAdapter.hpp"
 
 #include "datahandlinglibs/testutils/TestUtilities.hpp"
 
-#include "datahandlinglibs/models/FixedRateQueueModel.hpp"
 #include "datahandlinglibs/models/BinarySearchQueueModel.hpp"
+#include "datahandlinglibs/models/FixedRateQueueModel.hpp"
 #include "datahandlinglibs/models/SkipListLatencyBufferModel.hpp"
 
 #include "boost/test/unit_test.hpp"
 
-#include <iostream>
 #include <cmath>
-#include <sstream>
-#include <set>
+#include <iostream>
 #include <iterator>
+#include <set>
+#include <sstream>
 
 BOOST_AUTO_TEST_SUITE(FDReadoutRequestHandlers_test)
 
 BOOST_AUTO_TEST_CASE(FixedRateQueueModel_DUNEWIBEth)
 {
-    dunedaq::datahandlinglibs::test::test_request_model<
-            dunedaq::datahandlinglibs::FixedRateQueueModel,
-            dunedaq::fdreadoutlibs::types::DUNEWIBEthTypeAdapter>();
+  dunedaq::datahandlinglibs::test::test_request_model<dunedaq::datahandlinglibs::FixedRateQueueModel,
+                                                      dunedaq::fdreadoutlibs::types::DUNEWIBEthTypeAdapter>();
 }
 
 BOOST_AUTO_TEST_CASE(BinarySearchQueueModel_DUNEWIBEth)
 {
-    dunedaq::datahandlinglibs::test::test_request_model<
-            dunedaq::datahandlinglibs::BinarySearchQueueModel,
-            dunedaq::fdreadoutlibs::types::DUNEWIBEthTypeAdapter>();
+  dunedaq::datahandlinglibs::test::test_request_model<dunedaq::datahandlinglibs::BinarySearchQueueModel,
+                                                      dunedaq::fdreadoutlibs::types::DUNEWIBEthTypeAdapter>();
 }
 BOOST_AUTO_TEST_CASE(FixedRateQueueModel_DAPHNEStreamSuperChunk)
 {
-    dunedaq::datahandlinglibs::test::test_request_model<
-            dunedaq::datahandlinglibs::FixedRateQueueModel,
-            dunedaq::fdreadoutlibs::types::DAPHNEStreamSuperChunkTypeAdapter>();
+  dunedaq::datahandlinglibs::test::test_request_model<
+    dunedaq::datahandlinglibs::FixedRateQueueModel,
+    dunedaq::fdreadoutlibs::types::DAPHNEStreamSuperChunkTypeAdapter>();
 }
 
 BOOST_AUTO_TEST_CASE(BinarySearchQueueModel_DAPHNEStreamSuperChunk)
 {
-    dunedaq::datahandlinglibs::test::test_request_model<
-            dunedaq::datahandlinglibs::BinarySearchQueueModel,
-            dunedaq::fdreadoutlibs::types::DAPHNEStreamSuperChunkTypeAdapter>();
+  dunedaq::datahandlinglibs::test::test_request_model<
+    dunedaq::datahandlinglibs::BinarySearchQueueModel,
+    dunedaq::fdreadoutlibs::types::DAPHNEStreamSuperChunkTypeAdapter>();
 }
 
 BOOST_AUTO_TEST_CASE(SkipListLatencyBufferModel_DAPHNESuperChunk)
 {
-    dunedaq::datahandlinglibs::test::test_request_model<
-            dunedaq::datahandlinglibs::SkipListLatencyBufferModel,
-            dunedaq::fdreadoutlibs::types::DAPHNESuperChunkTypeAdapter>();
+  dunedaq::datahandlinglibs::test::test_request_model<dunedaq::datahandlinglibs::SkipListLatencyBufferModel,
+                                                      dunedaq::fdreadoutlibs::types::DAPHNESuperChunkTypeAdapter>();
 }
 
 BOOST_AUTO_TEST_CASE(FixedRateQueueModel_TDEEth)
 {
-    dunedaq::datahandlinglibs::test::test_request_model<
-            dunedaq::datahandlinglibs::FixedRateQueueModel,
-            dunedaq::fdreadoutlibs::types::TDEEthTypeAdapter>();
+  dunedaq::datahandlinglibs::test::test_request_model<dunedaq::datahandlinglibs::FixedRateQueueModel,
+                                                      dunedaq::fdreadoutlibs::types::TDEEthTypeAdapter>();
 }
 
 BOOST_AUTO_TEST_CASE(BinarySearchQueueModel_TDEEth)
 {
-    dunedaq::datahandlinglibs::test::test_request_model<
-            dunedaq::datahandlinglibs::BinarySearchQueueModel,
-            dunedaq::fdreadoutlibs::types::TDEEthTypeAdapter>();
+  dunedaq::datahandlinglibs::test::test_request_model<dunedaq::datahandlinglibs::BinarySearchQueueModel,
+                                                      dunedaq::fdreadoutlibs::types::TDEEthTypeAdapter>();
 }
 
-
 BOOST_AUTO_TEST_SUITE_END()
-
-

--- a/unittest/FDTypeAdaptersBuffers_test.cxx
+++ b/unittest/FDTypeAdaptersBuffers_test.cxx
@@ -8,56 +8,60 @@
 
 #define BOOST_TEST_MODULE FDTypeAdaptersBuffers_test // NOLINT
 
-#include "fdreadoutlibs/DUNEWIBEthTypeAdapter.hpp"
 #include "fdreadoutlibs/DAPHNEStreamSuperChunkTypeAdapter.hpp"
 #include "fdreadoutlibs/DAPHNESuperChunkTypeAdapter.hpp"
+#include "fdreadoutlibs/DUNEWIBEthTypeAdapter.hpp"
 #include "fdreadoutlibs/TDEEthTypeAdapter.hpp"
 
 #include "datahandlinglibs/testutils/TestUtilities.hpp"
 
-#include "datahandlinglibs/models/FixedRateQueueModel.hpp"
 #include "datahandlinglibs/models/BinarySearchQueueModel.hpp"
+#include "datahandlinglibs/models/FixedRateQueueModel.hpp"
 #include "datahandlinglibs/models/SkipListLatencyBufferModel.hpp"
-
 
 #include "boost/test/unit_test.hpp"
 
 #include <iostream>
-#include <sstream>
-#include <set>
 #include <iterator>
+#include <set>
+#include <sstream>
 
 BOOST_AUTO_TEST_SUITE(FDReadoutTypeAdaptersBuffers_test)
 
 BOOST_AUTO_TEST_CASE(FixedRateQueueModel_DUNEWIBEth)
 {
-    dunedaq::datahandlinglibs::test::test_queue_model<dunedaq::datahandlinglibs::FixedRateQueueModel,dunedaq::fdreadoutlibs::types::DUNEWIBEthTypeAdapter>();
+  dunedaq::datahandlinglibs::test::test_queue_model<dunedaq::datahandlinglibs::FixedRateQueueModel,
+                                                    dunedaq::fdreadoutlibs::types::DUNEWIBEthTypeAdapter>();
 }
 BOOST_AUTO_TEST_CASE(BinarySearchQueueModel_DUNEWIBEth)
 {
-    dunedaq::datahandlinglibs::test::test_queue_model<dunedaq::datahandlinglibs::BinarySearchQueueModel,dunedaq::fdreadoutlibs::types::DUNEWIBEthTypeAdapter>();
+  dunedaq::datahandlinglibs::test::test_queue_model<dunedaq::datahandlinglibs::BinarySearchQueueModel,
+                                                    dunedaq::fdreadoutlibs::types::DUNEWIBEthTypeAdapter>();
 }
 BOOST_AUTO_TEST_CASE(FixedRateQueueModel_DAPHNEStreamSuperChunk)
 {
-    dunedaq::datahandlinglibs::test::test_queue_model<dunedaq::datahandlinglibs::FixedRateQueueModel,dunedaq::fdreadoutlibs::types::DAPHNEStreamSuperChunkTypeAdapter>();
+  dunedaq::datahandlinglibs::test::test_queue_model<dunedaq::datahandlinglibs::FixedRateQueueModel,
+                                                    dunedaq::fdreadoutlibs::types::DAPHNEStreamSuperChunkTypeAdapter>();
 }
 BOOST_AUTO_TEST_CASE(BinarySearchQueueModel_DAPHNEStreamSuperChunk)
 {
-    dunedaq::datahandlinglibs::test::test_queue_model<dunedaq::datahandlinglibs::BinarySearchQueueModel,dunedaq::fdreadoutlibs::types::DAPHNEStreamSuperChunkTypeAdapter>();
+  dunedaq::datahandlinglibs::test::test_queue_model<dunedaq::datahandlinglibs::BinarySearchQueueModel,
+                                                    dunedaq::fdreadoutlibs::types::DAPHNEStreamSuperChunkTypeAdapter>();
 }
 BOOST_AUTO_TEST_CASE(SkipListLatencyBufferModel_DAPHNESuperChunk)
 {
-    dunedaq::datahandlinglibs::test::test_queue_model<dunedaq::datahandlinglibs::SkipListLatencyBufferModel,dunedaq::fdreadoutlibs::types::DAPHNESuperChunkTypeAdapter>();
+  dunedaq::datahandlinglibs::test::test_queue_model<dunedaq::datahandlinglibs::SkipListLatencyBufferModel,
+                                                    dunedaq::fdreadoutlibs::types::DAPHNESuperChunkTypeAdapter>();
 }
 BOOST_AUTO_TEST_CASE(FixedRateQueueModel_TDEEth)
 {
-    dunedaq::datahandlinglibs::test::test_queue_model<dunedaq::datahandlinglibs::FixedRateQueueModel,dunedaq::fdreadoutlibs::types::TDEEthTypeAdapter>();
+  dunedaq::datahandlinglibs::test::test_queue_model<dunedaq::datahandlinglibs::FixedRateQueueModel,
+                                                    dunedaq::fdreadoutlibs::types::TDEEthTypeAdapter>();
 }
 BOOST_AUTO_TEST_CASE(BinarySearchQueueModel_TDEEth)
 {
-    dunedaq::datahandlinglibs::test::test_queue_model<dunedaq::datahandlinglibs::BinarySearchQueueModel,dunedaq::fdreadoutlibs::types::TDEEthTypeAdapter>();
+  dunedaq::datahandlinglibs::test::test_queue_model<dunedaq::datahandlinglibs::BinarySearchQueueModel,
+                                                    dunedaq::fdreadoutlibs::types::TDEEthTypeAdapter>();
 }
 
 BOOST_AUTO_TEST_SUITE_END()
-
-


### PR DESCRIPTION
…ersBuffers_test.cxx. (no logic changes in this commit, just formatting).

I had noticed that this needed to be done when we were working on fdaq-v5.2.0, but I didn't want to clutter up the end-of-release work with a formatting change PR.  However, now that v5.2.0 is winding down, it seems like a reasonable time to do this.

To test the change, I'd suggest confirming that these unittests continue to run successfully, e.g. by running `dbt-unittest-summary.sh` with the `fdreadoutlibs` repo checked out into a local software area.