### PR TITLE
Using a (dummy) pds channel map in the DAPHNE frame processor

### DIFF
--- a/include/fdreadoutlibs/daphne/DAPHNEFrameProcessor.hpp
+++ b/include/fdreadoutlibs/daphne/DAPHNEFrameProcessor.hpp
@@ -17,6 +17,8 @@
 #include "iomanager/IOManager.hpp"
 #include "iomanager/Sender.hpp"
 
+#include "detchannelmaps/PDSChannelMap.hpp"
+
 #include "datahandlinglibs/models/TaskRawDataProcessorModel.hpp"
 #include "trigger/TriggerPrimitiveTypeAdapter.hpp"
 #include "fdreadoutlibs/FDReadoutIssues.hpp"
@@ -94,6 +96,8 @@ protected:
   dunedaq::trgdataformats::TriggerPrimitive peak_to_tp( dunedaq::fddetdataformats::DAPHNEFrame &frame, int i);
 
 private:
+
+  std::shared_ptr<detchannelmaps::PDSChannelMap> m_channel_map;
 
   std::shared_ptr<iomanager::SenderConcept<std::vector<trigger::TriggerPrimitiveTypeAdapter>>> m_tp_sink;
 

--- a/src/daphne/DAPHNEFrameProcessor.cpp
+++ b/src/daphne/DAPHNEFrameProcessor.cpp
@@ -46,6 +46,9 @@ DAPHNEFrameProcessor::conf(const appmodel::DataHandlerModule* conf)
   inherited::add_preprocess_task(std::bind(&DAPHNEFrameProcessor::timestamp_check, this, std::placeholders::_1));
   
   if (m_post_processing_enabled) { 
+
+    m_channel_map = dunedaq::detchannelmaps::make_pds_map("DummyHDPDSChannelMap");
+
     // Extract TPs back as a pre-processing task, due to LatencyBuffer post-proc issues using SkipList.
     inherited::add_preprocess_task(std::bind(&DAPHNEFrameProcessor::extract_tps, this, std::placeholders::_1));
   }
@@ -206,7 +209,14 @@ DAPHNEFrameProcessor::peak_to_tp(dunedaq::fddetdataformats::DAPHNEFrame &frame, 
   tp.samples_over_threshold = frame.peaks_data.get_samples_over_baseline(i);
   // FIXME : hard-coded channel map
   // WARNING: slot ids in DAPHNEs are all 0!
-  tp.channel = frame.daq_header.slot_id*100+frame.get_channel();
+  // tp.channel = frame.daq_header.slot_id*100+frame.get_channel();
+  tp.channel = m_channel_map->get_offline_channel_from_det_crate_slot_stream_chan(
+    frame.daq_header.det_id,
+    frame.daq_header.crate_id,
+    frame.daq_header.slot_id,
+    frame.daq_header.link_id,
+    frame.get_channel()
+  );
   tp.adc_integral = frame.peaks_data.get_adc_integral(i);
   tp.adc_peak = frame.peaks_data.get_adc_max(i);
   tp.detid = dunedaq::trgdataformats::INVALID_DETID;


### PR DESCRIPTION
The daphne offline channel assignment is hardcoded in the peak-to-tp convertion.
This PR introduces the use of a PDS channel map (needs DUNE-DAQ/detchannelmaps#58) in line with what is done for TPC frames.