### PR TITLE
CRT frame processors are added

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ daq_add_library(
   wibeth/*.cpp
   daphne/*.cpp
   tde/*.cpp
+  crt/*.cpp
   LINK_LIBRARIES ${FDREADOUTLIBS_DEPENDENCIES}
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(fdreadoutlibs VERSION 2.4.0)
+project(fdreadoutlibs VERSION 2.5.0)
 
 find_package(daq-cmake REQUIRED)
 

--- a/include/fdreadoutlibs/CRTBernTypeAdapter.hpp
+++ b/include/fdreadoutlibs/CRTBernTypeAdapter.hpp
@@ -79,6 +79,7 @@ struct CRTBernTypeAdapter
 
   size_t get_frame_size() { return kCRTBernFrameSize; }
 
+  static const constexpr size_t fixed_payload_size = kCRTBernFrameSize;
   static const constexpr daqdataformats::SourceID::Subsystem subsystem = daqdataformats::SourceID::Subsystem::kDetectorReadout;
   static const constexpr daqdataformats::FragmentType fragment_type = daqdataformats::FragmentType::kCRTBern;
   static const constexpr uint64_t expected_tick_difference = 64; // NOLINT(build/unsigned)

--- a/include/fdreadoutlibs/CRTGrenobleTypeAdapter.hpp
+++ b/include/fdreadoutlibs/CRTGrenobleTypeAdapter.hpp
@@ -79,6 +79,7 @@ struct CRTGrenobleTypeAdapter
 
   size_t get_frame_size() { return kCRTGrenobleFrameSize; }
 
+  static const constexpr size_t fixed_payload_size = kCRTGrenobleFrameSize;
   static const constexpr daqdataformats::SourceID::Subsystem subsystem = daqdataformats::SourceID::Subsystem::kDetectorReadout;
   static const constexpr daqdataformats::FragmentType fragment_type = daqdataformats::FragmentType::kCRTGrenoble;
   static const constexpr uint64_t expected_tick_difference = 64; // NOLINT(build/unsigned)

--- a/include/fdreadoutlibs/crt/CRTBernFrameProcessor.hpp
+++ b/include/fdreadoutlibs/crt/CRTBernFrameProcessor.hpp
@@ -1,0 +1,28 @@
+/**
+ * @file CRTBernFrameProcessor.hpp CRTBern specific Task based raw processor
+ *
+ * This is part of the DUNE DAQ , copyright 2022.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+#ifndef FDREADOUTLIBS_INCLUDE_FDREADOUTLIBS_CRT_CRTBERNFRAMEPROCESSOR_HPP_
+#define FDREADOUTLIBS_INCLUDE_FDREADOUTLIBS_CRT_CRTBERNFRAMEPROCESSOR_HPP_
+
+#include "datahandlinglibs/models/TaskRawDataProcessorModel.hpp"
+
+#include "fdreadoutlibs/CRTBernTypeAdapter.hpp"
+
+namespace dunedaq {
+namespace fdreadoutlibs {
+
+class CRTBernFrameProcessor : public datahandlinglibs::TaskRawDataProcessorModel<types::CRTBernTypeAdapter>
+{
+public:
+    CRTBernFrameProcessor(std::unique_ptr<datahandlinglibs::FrameErrorRegistry>& error_registry, bool processing_enabled);
+};
+
+} // namespace fdreadoutlibs
+} // namespace dunedaq
+
+#endif // FDREADOUTLIBS_INCLUDE_FDREADOUTLIBS_CRT_CRTBERNFRAMEPROCESSOR_HPP_
+

--- a/include/fdreadoutlibs/crt/CRTBernFrameProcessor.hpp
+++ b/include/fdreadoutlibs/crt/CRTBernFrameProcessor.hpp
@@ -18,7 +18,16 @@ namespace fdreadoutlibs {
 class CRTBernFrameProcessor : public datahandlinglibs::TaskRawDataProcessorModel<types::CRTBernTypeAdapter>
 {
 public:
-    CRTBernFrameProcessor(std::unique_ptr<datahandlinglibs::FrameErrorRegistry>& error_registry, bool processing_enabled);
+    explicit CRTBernFrameProcessor(std::unique_ptr<datahandlinglibs::FrameErrorRegistry>& error_registry, bool post_processing_enabled)
+            : datahandlinglibs::TaskRawDataProcessorModel<types::CRTBernTypeAdapter>(error_registry, post_processing_enabled)
+    {}
+
+    void conf(const appmodel::DataHandlerModule* conf) override;
+
+protected:
+    using dunedaq::datahandlinglibs::logging::TLVL_FRAME_RECEIVED;
+
+    void timestamp_check(types::CRTBernTypeAdapter* fp);
 };
 
 } // namespace fdreadoutlibs

--- a/include/fdreadoutlibs/crt/CRTGrenobleFrameProcessor.hpp
+++ b/include/fdreadoutlibs/crt/CRTGrenobleFrameProcessor.hpp
@@ -1,0 +1,28 @@
+/**
+ * @file CRTGrenobleFrameProcessor.hpp CRTGrenoble specific Task based raw processor
+ *
+ * This is part of the DUNE DAQ , copyright 2022.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+#ifndef FDREADOUTLIBS_INCLUDE_FDREADOUTLIBS_CRT_CRTGRENOBLEFRAMEPROCESSOR_HPP_
+#define FDREADOUTLIBS_INCLUDE_FDREADOUTLIBS_CRT_CRTGRENOBLEFRAMEPROCESSOR_HPP_
+
+#include "datahandlinglibs/models/TaskRawDataProcessorModel.hpp"
+
+#include "fdreadoutlibs/CRTGrenobleTypeAdapter.hpp"
+
+namespace dunedaq {
+namespace fdreadoutlibs {
+
+class CRTGrenobleFrameProcessor : public datahandlinglibs::TaskRawDataProcessorModel<types::CRTGrenobleTypeAdapter>
+{
+public:
+    CRTGrenobleFrameProcessor(std::unique_ptr<datahandlinglibs::FrameErrorRegistry>& error_registry, bool processing_enabled);
+};
+
+} // namespace fdreadoutlibs
+} // namespace dunedaq
+
+#endif // FDREADOUTLIBS_INCLUDE_FDREADOUTLIBS_CRT_CRTGRENOBLEFRAMEPROCESSOR_HPP_
+

--- a/include/fdreadoutlibs/crt/CRTGrenobleFrameProcessor.hpp
+++ b/include/fdreadoutlibs/crt/CRTGrenobleFrameProcessor.hpp
@@ -18,7 +18,16 @@ namespace fdreadoutlibs {
 class CRTGrenobleFrameProcessor : public datahandlinglibs::TaskRawDataProcessorModel<types::CRTGrenobleTypeAdapter>
 {
 public:
-    CRTGrenobleFrameProcessor(std::unique_ptr<datahandlinglibs::FrameErrorRegistry>& error_registry, bool processing_enabled);
+    explicit CRTGrenobleFrameProcessor(std::unique_ptr<datahandlinglibs::FrameErrorRegistry>& error_registry, bool post_processing_enabled)
+    : datahandlinglibs::TaskRawDataProcessorModel<types::CRTGrenobleTypeAdapter>(error_registry, post_processing_enabled)
+    {}
+
+    void conf(const appmodel::DataHandlerModule* conf) override;
+
+protected:
+    using dunedaq::datahandlinglibs::logging::TLVL_FRAME_RECEIVED;
+
+    void timestamp_check(types::CRTGrenobleTypeAdapter* fp);
 };
 
 } // namespace fdreadoutlibs

--- a/src/crt/CRTBernFrameProcessor.cpp
+++ b/src/crt/CRTBernFrameProcessor.cpp
@@ -11,10 +11,21 @@
 namespace dunedaq {
 namespace fdreadoutlibs {
 
-CRTBernFrameProcessor::CRTBernFrameProcessor(std::unique_ptr<datahandlinglibs::FrameErrorRegistry>& error_registry, bool processing_enabled)
-  : TaskRawDataProcessorModel<types::CRTBernTypeAdapter>(error_registry, processing_enabled)
-{
-}
-    
+    void CRTBernFrameProcessor::conf(const appmodel::DataHandlerModule* /*conf*/)
+    {
+        TLOG() << "Registering processing tasks...";
+        datahandlinglibs::TaskRawDataProcessorModel<types::CRTBernTypeAdapter>::add_preprocess_task(std::bind(&CRTBernFrameProcessor::timestamp_check, this, std::placeholders::_1));
+    }
+
+    void CRTBernFrameProcessor::timestamp_check(types::CRTBernTypeAdapter* fp)
+    {
+        static const uint64_t k_clock_frequency = 62500000; // NOLINT(build/unsigned)
+        auto current_ts = fp->get_timestamp();
+        TLOG_DEBUG(TLVL_FRAME_RECEIVED) << "Received CRTBern frame timestamp value of " << current_ts << " ticks (..." << std::fixed << std::setprecision(8) << (static_cast<double>(current_ts % (k_clock_frequency*1000)) / static_cast<double>(k_clock_frequency)) << " sec)";// NOLINT
+
+        if(current_ts > m_last_processed_daq_ts) m_last_processed_daq_ts = current_ts;
+    }
+
+
 } // namespace fdreadoutlibs
 } // namespace dunedaq    

--- a/src/crt/CRTBernFrameProcessor.cpp
+++ b/src/crt/CRTBernFrameProcessor.cpp
@@ -1,0 +1,20 @@
+/**
+ * @file CRTBernFrameProcessor.hpp CRTBern specific Task based raw processor
+ *
+ * This is part of the DUNE DAQ , copyright 2023.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "fdreadoutlibs/crt/CRTBernFrameProcessor.hpp" // NOLINT(build/include)
+
+namespace dunedaq {
+namespace fdreadoutlibs {
+
+CRTBernFrameProcessor::CRTBernFrameProcessor(std::unique_ptr<datahandlinglibs::FrameErrorRegistry>& error_registry, bool processing_enabled)
+  : TaskRawDataProcessorModel<types::CRTBernTypeAdapter>(error_registry, processing_enabled)
+{
+}
+    
+} // namespace fdreadoutlibs
+} // namespace dunedaq    

--- a/src/crt/CRTGrenobleFrameProcessor.cpp
+++ b/src/crt/CRTGrenobleFrameProcessor.cpp
@@ -11,10 +11,20 @@
 namespace dunedaq {
 namespace fdreadoutlibs {
 
-CRTGrenobleFrameProcessor::CRTGrenobleFrameProcessor(std::unique_ptr<datahandlinglibs::FrameErrorRegistry>& error_registry, bool processing_enabled)
-  : TaskRawDataProcessorModel<types::CRTGrenobleTypeAdapter>(error_registry, processing_enabled)
-{
-}
+    void CRTGrenobleFrameProcessor::conf(const appmodel::DataHandlerModule* /*conf*/)
+    {
+        TLOG() << "Registering processing tasks...";
+        datahandlinglibs::TaskRawDataProcessorModel<types::CRTGrenobleTypeAdapter>::add_preprocess_task(std::bind(&CRTGrenobleFrameProcessor::timestamp_check, this, std::placeholders::_1));
+    }
+
+    void CRTGrenobleFrameProcessor::timestamp_check(types::CRTGrenobleTypeAdapter* fp)
+    {
+        static const uint64_t k_clock_frequency = 62500000; // NOLINT(build/unsigned)
+        auto current_ts = fp->get_timestamp();
+        TLOG_DEBUG(TLVL_FRAME_RECEIVED) << "Received CRTGrenoble frame timestamp value of " << current_ts << " ticks (..." << std::fixed << std::setprecision(8) << (static_cast<double>(current_ts % (k_clock_frequency*1000)) / static_cast<double>(k_clock_frequency)) << " sec)";// NOLINT
+
+        if(current_ts > m_last_processed_daq_ts) m_last_processed_daq_ts = current_ts;
+    }
 
 } // namespace fdreadoutlibs
 } // namespace dunedaq    

--- a/src/crt/CRTGrenobleFrameProcessor.cpp
+++ b/src/crt/CRTGrenobleFrameProcessor.cpp
@@ -1,0 +1,20 @@
+/**
+ * @file CRTGrenobleFrameProcessor.hpp CRTGrenoble specific Task based raw processor
+ *
+ * This is part of the DUNE DAQ , copyright 2023.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "fdreadoutlibs/crt/CRTGrenobleFrameProcessor.hpp" // NOLINT(build/include)
+
+namespace dunedaq {
+namespace fdreadoutlibs {
+
+CRTGrenobleFrameProcessor::CRTGrenobleFrameProcessor(std::unique_ptr<datahandlinglibs::FrameErrorRegistry>& error_registry, bool processing_enabled)
+  : TaskRawDataProcessorModel<types::CRTGrenobleTypeAdapter>(error_registry, processing_enabled)
+{
+}
+
+} // namespace fdreadoutlibs
+} // namespace dunedaq    


### PR DESCRIPTION
This change was done to make [Create readout for CRT frames](https://github.com/DUNE-DAQ/fdreadoutmodules/pull/52/) work but I need help with filling in the classes. (*)

(*) Please see the comment below.

<details><summary>Create readout for CRT frames</summary>
<p>

![Diagramme sans nom drawio](https://github.com/user-attachments/assets/b1d92df5-7584-4e78-9a48-63fef051c541)
After `SocketReaderModule` reads data from the socket (`CRTBernFrame`/`CRTGrenobleFrame`) it puts the read data on a queue to be processed by `DataHandlingModel`.

</p>
</details> 