### PR TITLE
Processor Metrics monitoring 

### DIFF
--- a/include/fdreadoutlibs/wibeth/WIBEthFrameProcessor.hpp
+++ b/include/fdreadoutlibs/wibeth/WIBEthFrameProcessor.hpp
@@ -120,11 +120,13 @@ protected:
 
 private:
   bool m_first_hit = true;
+  bool m_tpg_metric_collect_enabled{true}; // FIXME: Make this configurable
   std::unique_ptr<tpglibs::TPGenerator> m_tp_generator;
   std::vector<std::pair<std::string, nlohmann::json>> m_tpg_configs;
   uint32_t m_tp_max_width;
   std::set<unsigned int> m_channel_mask_set;
   uint16_t m_tpg_threshold_selected;
+  uint16_t m_tpg_metric_collect_counter{0};
 
   std::map<uint, std::atomic<int>> m_tp_channel_rate_map;
 

--- a/include/fdreadoutlibs/wibeth/WIBEthFrameProcessor.hpp
+++ b/include/fdreadoutlibs/wibeth/WIBEthFrameProcessor.hpp
@@ -71,7 +71,21 @@ public:
 protected:
   virtual void generate_opmon_data() override;
 
+  /**
+   * Publishes collected processor metrics to opmon, currently called in generate_opmon_data()
+   * */
   void publish_processor_metric_to_opmon();
+
+  /**
+   * Publishes collected processor metrics to opmon, with aggregation of metrics to summary statistics across physical planes
+   * */
+  void publish_processor_metric_to_opmon_with_aggregation(); 
+
+  /**
+   * Calculates summary statistics of metrics across physical planes
+   * */
+  void calculate_metric_summary_across_planes(const std::unordered_map<dunedaq::trgdataformats::channel_t, std::vector<std::pair<std::string, int16_t>>>& metrics,
+    const std::string& item_name, int16_t plane_number, uint32_t &mean, uint32_t &min, uint32_t &max, double &stddev, dunedaq::trgdataformats::channel_t &min_channel_id, dunedaq::trgdataformats::channel_t &max_channel_id);
 
   // Internals
   dunedaq::daqdataformats::timestamp_t m_previous_ts = 0;
@@ -130,7 +144,6 @@ private:
   uint32_t m_tp_max_width;
   std::set<unsigned int> m_channel_mask_set;
   uint16_t m_tpg_threshold_selected;
-  std::atomic<bool> m_update_metric_opmon {true};
 
   std::map<uint, std::atomic<int>> m_tp_channel_rate_map;
 

--- a/include/fdreadoutlibs/wibeth/WIBEthFrameProcessor.hpp
+++ b/include/fdreadoutlibs/wibeth/WIBEthFrameProcessor.hpp
@@ -71,6 +71,8 @@ public:
 protected:
   virtual void generate_opmon_data() override;
 
+  void publish_processor_metric_to_opmon();
+
   // Internals
   dunedaq::daqdataformats::timestamp_t m_previous_ts = 0;
   dunedaq::daqdataformats::timestamp_t m_current_ts = 0;

--- a/include/fdreadoutlibs/wibeth/WIBEthFrameProcessor.hpp
+++ b/include/fdreadoutlibs/wibeth/WIBEthFrameProcessor.hpp
@@ -82,12 +82,13 @@ protected:
   void publish_processor_metric_to_opmon_with_aggregation(); 
 
   /**
-   * Calculates summary statistics of metrics across physical planes
+   * Optimized version that calculates all metric summaries across all planes in a single pass
+   * Returns a map of plane_number -> map of metric_name -> summary statistics
    * */
-  void calculate_metric_summary_across_planes(const std::unordered_map<dunedaq::trgdataformats::channel_t, std::vector<std::pair<std::string, int16_t>>>& metrics,
-    const std::string& item_name, int16_t plane_number, float &mean, int16_t &min, int16_t &max, float &stddev, dunedaq::trgdataformats::channel_t &min_channel_id, dunedaq::trgdataformats::channel_t &max_channel_id);
+  std::map<int16_t, std::map<std::string, std::tuple<float, int16_t, int16_t, float, dunedaq::trgdataformats::channel_t, dunedaq::trgdataformats::channel_t>>> 
+  calculate_all_metric_summaries_across_planes(const std::unordered_map<dunedaq::trgdataformats::channel_t, std::vector<std::pair<std::string, int16_t>>>& metrics);
 
-  // Internals
+// Internals
   dunedaq::daqdataformats::timestamp_t m_previous_ts = 0;
   dunedaq::daqdataformats::timestamp_t m_current_ts = 0;
 

--- a/include/fdreadoutlibs/wibeth/WIBEthFrameProcessor.hpp
+++ b/include/fdreadoutlibs/wibeth/WIBEthFrameProcessor.hpp
@@ -120,7 +120,7 @@ protected:
 
 private:
   bool m_first_hit = true;
-  bool m_tpg_metric_collect_enabled{true}; // FIXME: Make this configurable
+  bool m_tpg_metric_collect_enabled{false}; // FIXME: Make this configurable
   std::unique_ptr<tpglibs::TPGenerator> m_tp_generator;
   std::vector<std::pair<std::string, nlohmann::json>> m_tpg_configs;
   uint32_t m_tp_max_width;

--- a/include/fdreadoutlibs/wibeth/WIBEthFrameProcessor.hpp
+++ b/include/fdreadoutlibs/wibeth/WIBEthFrameProcessor.hpp
@@ -138,7 +138,7 @@ protected:
 private:
   bool m_first_hit = true;
   bool m_tpg_metric_collect_enabled{false};
-  uint32_t m_metric_collect_opmon_rate { 128 };
+  uint32_t m_metric_collect_opmon_period { 128 };
   std::unique_ptr<tpglibs::TPGenerator> m_tp_generator;
   std::vector<std::pair<std::string, nlohmann::json>> m_tpg_configs;
   uint32_t m_tp_max_width;

--- a/include/fdreadoutlibs/wibeth/WIBEthFrameProcessor.hpp
+++ b/include/fdreadoutlibs/wibeth/WIBEthFrameProcessor.hpp
@@ -85,7 +85,7 @@ protected:
    * Calculates summary statistics of metrics across physical planes
    * */
   void calculate_metric_summary_across_planes(const std::unordered_map<dunedaq::trgdataformats::channel_t, std::vector<std::pair<std::string, int16_t>>>& metrics,
-    const std::string& item_name, int16_t plane_number, uint32_t &mean, uint32_t &min, uint32_t &max, double &stddev, dunedaq::trgdataformats::channel_t &min_channel_id, dunedaq::trgdataformats::channel_t &max_channel_id);
+    const std::string& item_name, int16_t plane_number, float &mean, int16_t &min, int16_t &max, float &stddev, dunedaq::trgdataformats::channel_t &min_channel_id, dunedaq::trgdataformats::channel_t &max_channel_id);
 
   // Internals
   dunedaq::daqdataformats::timestamp_t m_previous_ts = 0;

--- a/include/fdreadoutlibs/wibeth/WIBEthFrameProcessor.hpp
+++ b/include/fdreadoutlibs/wibeth/WIBEthFrameProcessor.hpp
@@ -120,13 +120,14 @@ protected:
 
 private:
   bool m_first_hit = true;
-  bool m_tpg_metric_collect_enabled{false}; // FIXME: Make this configurable
+  bool m_tpg_metric_collect_enabled{true}; // FIXME: Make this configurable
+  uint32_t m_metric_collect_opmon_rate { 128 };
   std::unique_ptr<tpglibs::TPGenerator> m_tp_generator;
   std::vector<std::pair<std::string, nlohmann::json>> m_tpg_configs;
   uint32_t m_tp_max_width;
   std::set<unsigned int> m_channel_mask_set;
   uint16_t m_tpg_threshold_selected;
-  uint16_t m_tpg_metric_collect_counter{0};
+  std::atomic<bool> m_update_metric_opmon {true};
 
   std::map<uint, std::atomic<int>> m_tp_channel_rate_map;
 

--- a/include/fdreadoutlibs/wibeth/WIBEthFrameProcessor.hpp
+++ b/include/fdreadoutlibs/wibeth/WIBEthFrameProcessor.hpp
@@ -138,7 +138,6 @@ private:
   bool m_first_hit = true;
   bool m_tpg_metric_collect_enabled{false};
   uint32_t m_metric_collect_opmon_rate { 128 };
-  uint32_t m_frame_counter_for_metrics { 0 };
   std::unique_ptr<tpglibs::TPGenerator> m_tp_generator;
   std::vector<std::pair<std::string, nlohmann::json>> m_tpg_configs;
   uint32_t m_tp_max_width;

--- a/include/fdreadoutlibs/wibeth/WIBEthFrameProcessor.hpp
+++ b/include/fdreadoutlibs/wibeth/WIBEthFrameProcessor.hpp
@@ -120,8 +120,9 @@ protected:
 
 private:
   bool m_first_hit = true;
-  bool m_tpg_metric_collect_enabled{true}; // FIXME: Make this configurable
+  bool m_tpg_metric_collect_enabled{false};
   uint32_t m_metric_collect_opmon_rate { 128 };
+  uint32_t m_frame_counter_for_metrics { 0 };
   std::unique_ptr<tpglibs::TPGenerator> m_tp_generator;
   std::vector<std::pair<std::string, nlohmann::json>> m_tpg_configs;
   uint32_t m_tp_max_width;

--- a/src/wibeth/WIBEthFrameProcessor.cpp
+++ b/src/wibeth/WIBEthFrameProcessor.cpp
@@ -145,7 +145,7 @@ WIBEthFrameProcessor::conf(const appmodel::DataHandlerModule* conf)
       }
 
       m_tpg_metric_collect_enabled = proc_conf->get_metric_collect_enable();
-      m_metric_collect_opmon_rate = proc_conf->get_metric_collect_opmon_rate();
+      m_metric_collect_opmon_period = proc_conf->get_metric_collect_opmon_rate();
 
       m_tp_generator->set_metric_collector_enable_state(m_tpg_metric_collect_enabled);
 
@@ -478,7 +478,7 @@ WIBEthFrameProcessor::find_hits(constframeptr fp)
 
   std::vector<trgdataformats::TriggerPrimitive> tps = (*m_tp_generator)(wfptr);
   m_frame_counter.fetch_add(1, std::memory_order_relaxed);
-  if (m_tpg_metric_collect_enabled && m_frame_counter.load(std::memory_order_relaxed) % m_metric_collect_opmon_rate == 0) {
+  if (m_tpg_metric_collect_enabled && m_frame_counter.load(std::memory_order_relaxed) % m_metric_collect_opmon_period == 0) {
     m_tp_generator->signal_metric_collection();
   }
 

--- a/src/wibeth/WIBEthFrameProcessor.cpp
+++ b/src/wibeth/WIBEthFrameProcessor.cpp
@@ -218,8 +218,9 @@ WIBEthFrameProcessor::generate_opmon_data()
      m_t0 = now;
 
      publish_processor_metric_to_opmon();
-
+     publish_processor_metric_to_opmon_with_aggregation();
    }
+   
    inherited::generate_opmon_data();
  }
 
@@ -240,6 +241,98 @@ WIBEthFrameProcessor::generate_opmon_data()
     }
   }
  }
+
+ void
+ WIBEthFrameProcessor::calculate_metric_summary_across_planes(const std::unordered_map<dunedaq::trgdataformats::channel_t, std::vector<std::pair<std::string, int16_t>>>& metrics, const std::string& item_name,
+    int16_t plane_number, uint32_t &mean, uint32_t &min, uint32_t &max, double &stddev, dunedaq::trgdataformats::channel_t &min_channel_id, dunedaq::trgdataformats::channel_t &max_channel_id) {
+    mean = 0;
+    min = std::numeric_limits<uint32_t>::max();
+    max = std::numeric_limits<uint32_t>::min();
+    min_channel_id = 0;
+    max_channel_id = 0;
+    uint32_t num_samples = 0;
+    
+    // First pass: collect all values and calculate sum, min, max
+    std::vector<double> values;
+    for (const auto& [channel, vec] : metrics) {
+      if (m_channel_map->get_plane_from_offline_channel(channel) == plane_number) {
+        for (const auto& [name, val] : vec) {
+          if (name == item_name) {
+            values.push_back(static_cast<double>(val));
+            if (val < min) {
+              min = val;
+              min_channel_id = channel;
+            }
+            if (val > max) {
+              max = val;
+              max_channel_id = channel;
+            }
+            num_samples++;
+          }
+        }
+      }
+    }
+    
+    if (num_samples == 0) {
+      mean = 0;
+      stddev = 0.0;
+      return;
+    }
+    
+    // Calculate mean
+    double sum = 0.0;
+    for (double x : values) sum += x;
+    double mean_double = sum / values.size();
+    mean = static_cast<uint32_t>(mean_double);
+    
+    // Second pass: calculate standard deviation using stable two-pass method
+    double sq_diff_sum = 0.0;
+    for (double x : values) {
+      double d = x - mean_double;
+      sq_diff_sum += d * d;
+    }
+    double variance = sq_diff_sum / (values.size() - 1);
+    stddev = std::sqrt(variance);
+ }
+
+void
+WIBEthFrameProcessor::publish_processor_metric_to_opmon_with_aggregation() {
+  if (m_tpg_metric_collect_enabled && m_tp_generator) {
+    auto metrics = m_tp_generator->get_processor_metrics();
+    // Calculate the set of all plane numbers
+    std::set<int16_t> plane_numbers;
+    std::set<std::string> metric_names;
+    for (const auto& [channel, vec] : metrics) {
+      if (m_channel_map) {
+        int16_t plane = m_channel_map->get_plane_from_offline_channel(channel);
+        plane_numbers.insert(plane);
+      }
+      for (const auto& [name, val] : vec) {
+        metric_names.insert(name);
+      }
+    }
+    
+    for (const auto& plane : plane_numbers) {
+      for (const auto& metric_name : metric_names) {
+        uint32_t mean = 0;
+        uint32_t min = 0;
+        uint32_t max = 0;
+        double stddev = 0.0;
+        dunedaq::trgdataformats::channel_t min_channel_id = 0;
+        dunedaq::trgdataformats::channel_t max_channel_id = 0;
+        calculate_metric_summary_across_planes(metrics, metric_name, plane, mean, min, max, stddev, min_channel_id, max_channel_id);
+        datahandlinglibs::opmon::TPGProcessorReducedInfo info;
+        info.set_mean(mean);
+        info.set_max(max);
+        info.set_min(min);
+        info.set_standard_dev(stddev);
+        info.set_max_channel_id(max_channel_id);
+        info.set_min_channel_id(min_channel_id);
+        publish(std::move(info), {{"plane", std::to_string(plane)}, {"metric", metric_name}});
+      }
+    }
+  }
+}
 
 
 /**
@@ -392,7 +485,6 @@ WIBEthFrameProcessor::find_hits(constframeptr fp)
   m_frame_counter_for_metrics++;
   if (m_tpg_metric_collect_enabled && m_tp_generator && m_frame_counter_for_metrics % m_metric_collect_opmon_rate == 0) {
     m_tp_generator->signal_metric_collection();
-    m_update_metric_opmon.store(true, std::memory_order_release);
   }
 
   for (const auto& tp : tps) {

--- a/src/wibeth/WIBEthFrameProcessor.cpp
+++ b/src/wibeth/WIBEthFrameProcessor.cpp
@@ -470,9 +470,8 @@ WIBEthFrameProcessor::find_hits(constframeptr fp)
   }
 
   std::vector<trgdataformats::TriggerPrimitive> tps = (*m_tp_generator)(wfptr);
-  m_frame_counter++;
-  m_frame_counter_for_metrics++;
-  if (m_tpg_metric_collect_enabled && m_tp_generator && m_frame_counter_for_metrics % m_metric_collect_opmon_rate == 0) {
+  m_frame_counter.fetch_add(1, std::memory_order_relaxed);
+  if (m_tpg_metric_collect_enabled && m_frame_counter.load(std::memory_order_relaxed) % m_metric_collect_opmon_rate == 0) {
     m_tp_generator->signal_metric_collection();
   }
 
@@ -489,7 +488,7 @@ WIBEthFrameProcessor::find_hits(constframeptr fp)
     m_tp_channel_rate_map[tp.channel]++;
   }
 
-  if (m_frame_counter >= 100) { // FIXME: Hard-coding 100 for now. This should be defined elsewhere or configurable.
+  if (m_frame_counter.load(std::memory_order_relaxed) % 100 == 0) { // FIXME: Hard-coding 100 for now. This should be defined elsewhere or configurable.
     for (int i = 0; i < 3; i++) {
       int new_tps = m_tpa_vectors[i].size();
       if (new_tps == 0) {
@@ -507,7 +506,6 @@ WIBEthFrameProcessor::find_hits(constframeptr fp)
         nhits += new_tps;
       }
     }
-    m_frame_counter = 0;
   }
 
   m_tpg_hits_count += nhits;

--- a/src/wibeth/WIBEthFrameProcessor.cpp
+++ b/src/wibeth/WIBEthFrameProcessor.cpp
@@ -242,74 +242,83 @@ WIBEthFrameProcessor::generate_opmon_data()
   }
  }
 
- void
-WIBEthFrameProcessor::calculate_metric_summary_across_planes(const std::unordered_map<dunedaq::trgdataformats::channel_t, std::vector<std::pair<std::string, int16_t>>>& metrics, const std::string& item_name,
-    int16_t plane_number, float &mean, int16_t &min, int16_t &max, float &stddev, dunedaq::trgdataformats::channel_t &min_channel_id, dunedaq::trgdataformats::channel_t &max_channel_id) {
-    // Initialize with default values
-    mean = 0;
-    min = std::numeric_limits<int16_t>::max();
-    max = std::numeric_limits<int16_t>::min();
-    min_channel_id = max_channel_id = 0;
+std::map<int16_t, std::map<std::string, std::tuple<float, int16_t, int16_t, float, dunedaq::trgdataformats::channel_t, dunedaq::trgdataformats::channel_t>>> 
+WIBEthFrameProcessor::calculate_all_metric_summaries_across_planes(const std::unordered_map<dunedaq::trgdataformats::channel_t, std::vector<std::pair<std::string, int16_t>>>& metrics) {
+    // Structure to hold all statistics: plane -> metric -> (mean, min, max, stddev, min_channel_id, max_channel_id)
+    std::map<int16_t, std::map<std::string, std::tuple<float, int16_t, int16_t, float, dunedaq::trgdataformats::channel_t, dunedaq::trgdataformats::channel_t>>> all_stats;
     
-    // Collect values and calculate mean in single pass
-    std::vector<int16_t> values;
-    double sum = 0.0;
+    // Structure to accumulate statistics: plane -> metric -> (count, mean, M2, min, max, min_channel_id, max_channel_id)
+    std::map<int16_t, std::map<std::string, std::tuple<size_t, double, double, int16_t, int16_t, dunedaq::trgdataformats::channel_t, dunedaq::trgdataformats::channel_t>>> accumulators;
+    
+    // Single pass through all metrics to collect data using Welford's online algorithm for variance
     for (const auto& [channel, vec] : metrics) {
-        if (m_channel_map->get_plane_from_offline_channel(channel) == plane_number) {
-            for (const auto& [name, val] : vec) {
-                if (name == item_name) {
-                    values.push_back(val);
-                    sum += val;
-                    if (val < min) { min = val; min_channel_id = channel; }
-                    if (val > max) { max = val; max_channel_id = channel; }
-                }
+        if (!m_channel_map) continue;
+        
+        int16_t plane = m_channel_map->get_plane_from_offline_channel(channel);
+        
+        for (const auto& [name, val] : vec) {
+            auto& [count, mean, M2, min, max, min_channel_id, max_channel_id] = accumulators[plane][name];
+            
+            count++;
+            
+            if (count == 1 || val < min) {
+                min = val;
+                min_channel_id = channel;
+            }
+            if (count == 1 || val > max) {
+                max = val;
+                max_channel_id = channel;
+            }
+            
+            // Welford's online algorithm for variance calculation
+            if (count == 1) {
+                // First value: initialize mean and M2
+                mean = val;
+                M2 = 0.0;
+            } else {
+                // Update mean and M2 using Welford's algorithm
+                double delta = val - mean;
+                mean += delta / count;
+                double delta2 = val - mean;
+                M2 += delta * delta2;
             }
         }
     }
     
-    if (values.empty()) {
-        stddev = 0.0;
-        return;
+    // Calculate final statistics from accumulated data
+    for (const auto& [plane, metric_map] : accumulators) {
+        for (const auto& [metric_name, acc_data] : metric_map) {
+            const auto& [count, mean, M2, min, max, min_channel_id, max_channel_id] = acc_data;
+            
+            if (count == 0) continue;
+            
+            float stddev = 0.0f;
+            
+            // Calculate standard deviation using accumulated M2
+            if (count > 1) {
+                stddev = std::sqrt(M2 / (count - 1));
+            }
+            
+            all_stats[plane][metric_name] = std::make_tuple(static_cast<float>(mean), min, max, stddev, min_channel_id, max_channel_id);
+        }
     }
     
-    // Calculate mean
-    mean = static_cast<float>(sum) / static_cast<float>(values.size());
-    
-    // Calculate standard deviation
-    double variance = 0.0;
-    for (int16_t val : values) {
-        double diff = static_cast<double>(val) - mean;
-        variance += diff * diff;
-    }
-    stddev = std::sqrt(variance / (values.size() - 1));
+    return all_stats;
 }
 
 void
 WIBEthFrameProcessor::publish_processor_metric_to_opmon_with_aggregation() {
   if (m_tpg_metric_collect_enabled && m_tp_generator) {
     auto metrics = m_tp_generator->get_processor_metrics();
-    // Calculate the set of all plane numbers
-    std::set<int16_t> plane_numbers;
-    std::set<std::string> metric_names;
-    for (const auto& [channel, vec] : metrics) {
-      if (m_channel_map) {
-        int16_t plane = m_channel_map->get_plane_from_offline_channel(channel);
-        plane_numbers.insert(plane);
-      }
-      for (const auto& [name, val] : vec) {
-        metric_names.insert(name);
-      }
-    }
     
-    for (const auto& plane : plane_numbers) {
-      for (const auto& metric_name : metric_names) {
-        float mean = 0;
-        int16_t min = 0;
-        int16_t max = 0;
-        float stddev = 0.0;
-        dunedaq::trgdataformats::channel_t min_channel_id = 0;
-        dunedaq::trgdataformats::channel_t max_channel_id = 0;
-        calculate_metric_summary_across_planes(metrics, metric_name, plane, mean, min, max, stddev, min_channel_id, max_channel_id);
+    // Use optimized single-pass calculation for all metrics across all planes
+    auto all_stats = calculate_all_metric_summaries_across_planes(metrics);
+    
+    // Publish all calculated statistics
+    for (const auto& [plane, metric_map] : all_stats) {
+      for (const auto& [metric_name, stats] : metric_map) {
+        const auto& [mean, min, max, stddev, min_channel_id, max_channel_id] = stats;
+        
         datahandlinglibs::opmon::TPGProcessorReducedInfo info;
         info.set_average(mean);
         info.set_max(max);

--- a/src/wibeth/WIBEthFrameProcessor.cpp
+++ b/src/wibeth/WIBEthFrameProcessor.cpp
@@ -243,57 +243,46 @@ WIBEthFrameProcessor::generate_opmon_data()
  }
 
  void
- WIBEthFrameProcessor::calculate_metric_summary_across_planes(const std::unordered_map<dunedaq::trgdataformats::channel_t, std::vector<std::pair<std::string, int16_t>>>& metrics, const std::string& item_name,
-    int16_t plane_number, uint32_t &mean, uint32_t &min, uint32_t &max, double &stddev, dunedaq::trgdataformats::channel_t &min_channel_id, dunedaq::trgdataformats::channel_t &max_channel_id) {
+WIBEthFrameProcessor::calculate_metric_summary_across_planes(const std::unordered_map<dunedaq::trgdataformats::channel_t, std::vector<std::pair<std::string, int16_t>>>& metrics, const std::string& item_name,
+    int16_t plane_number, float &mean, int16_t &min, int16_t &max, float &stddev, dunedaq::trgdataformats::channel_t &min_channel_id, dunedaq::trgdataformats::channel_t &max_channel_id) {
+    // Initialize with default values
     mean = 0;
-    min = std::numeric_limits<uint32_t>::max();
-    max = std::numeric_limits<uint32_t>::min();
-    min_channel_id = 0;
-    max_channel_id = 0;
-    uint32_t num_samples = 0;
+    min = std::numeric_limits<int16_t>::max();
+    max = std::numeric_limits<int16_t>::min();
+    min_channel_id = max_channel_id = 0;
     
-    // First pass: collect all values and calculate sum, min, max
-    std::vector<double> values;
+    // Collect values and calculate mean in single pass
+    std::vector<int16_t> values;
+    double sum = 0.0;
     for (const auto& [channel, vec] : metrics) {
-      if (m_channel_map->get_plane_from_offline_channel(channel) == plane_number) {
-        for (const auto& [name, val] : vec) {
-          if (name == item_name) {
-            values.push_back(static_cast<double>(val));
-            if (val < min) {
-              min = val;
-              min_channel_id = channel;
+        if (m_channel_map->get_plane_from_offline_channel(channel) == plane_number) {
+            for (const auto& [name, val] : vec) {
+                if (name == item_name) {
+                    values.push_back(val);
+                    sum += val;
+                    if (val < min) { min = val; min_channel_id = channel; }
+                    if (val > max) { max = val; max_channel_id = channel; }
+                }
             }
-            if (val > max) {
-              max = val;
-              max_channel_id = channel;
-            }
-            num_samples++;
-          }
         }
-      }
     }
     
-    if (num_samples == 0) {
-      mean = 0;
-      stddev = 0.0;
-      return;
+    if (values.empty()) {
+        stddev = 0.0;
+        return;
     }
     
     // Calculate mean
-    double sum = 0.0;
-    for (double x : values) sum += x;
-    double mean_double = sum / values.size();
-    mean = static_cast<uint32_t>(mean_double);
+    mean = static_cast<float>(sum) / static_cast<float>(values.size());
     
-    // Second pass: calculate standard deviation using stable two-pass method
-    double sq_diff_sum = 0.0;
-    for (double x : values) {
-      double d = x - mean_double;
-      sq_diff_sum += d * d;
+    // Calculate standard deviation
+    double variance = 0.0;
+    for (int16_t val : values) {
+        double diff = static_cast<double>(val) - mean;
+        variance += diff * diff;
     }
-    double variance = sq_diff_sum / (values.size() - 1);
-    stddev = std::sqrt(variance);
- }
+    stddev = std::sqrt(variance / (values.size() - 1));
+}
 
 void
 WIBEthFrameProcessor::publish_processor_metric_to_opmon_with_aggregation() {
@@ -314,10 +303,10 @@ WIBEthFrameProcessor::publish_processor_metric_to_opmon_with_aggregation() {
     
     for (const auto& plane : plane_numbers) {
       for (const auto& metric_name : metric_names) {
-        uint32_t mean = 0;
-        uint32_t min = 0;
-        uint32_t max = 0;
-        double stddev = 0.0;
+        float mean = 0;
+        int16_t min = 0;
+        int16_t max = 0;
+        float stddev = 0.0;
         dunedaq::trgdataformats::channel_t min_channel_id = 0;
         dunedaq::trgdataformats::channel_t max_channel_id = 0;
         calculate_metric_summary_across_planes(metrics, metric_name, plane, mean, min, max, stddev, min_channel_id, max_channel_id);

--- a/src/wibeth/WIBEthFrameProcessor.cpp
+++ b/src/wibeth/WIBEthFrameProcessor.cpp
@@ -217,8 +217,21 @@ WIBEthFrameProcessor::generate_opmon_data()
      }
      m_t0 = now;
 
-     if (m_tpg_metric_collect_enabled && m_update_metric_opmon.load(std::memory_order_release)) {
+     if (m_tpg_metric_collect_enabled) {
        auto metrics = m_tp_generator->get_processor_metrics();
+
+       for (const auto& [channel, vec] : metrics) {
+        datahandlinglibs::opmon::TPGProcessorInfo tpg_proc_info;
+        for (const auto& [name, val] : vec) {
+          if (name == "m_pedestal") {
+            tpg_proc_info.set_pedestal(val);
+          } else if (name == "m_accum")
+          {
+            tpg_proc_info.set_accum(val);
+          }
+        }
+        publish(std::move(tpg_proc_info), {{"channel", std::to_string(channel)}});
+      }
      }
 
    }
@@ -373,7 +386,8 @@ WIBEthFrameProcessor::find_hits(constframeptr fp)
 
   std::vector<trgdataformats::TriggerPrimitive> tps = (*m_tp_generator)(wfptr);
   m_frame_counter++;
-  if (m_tpg_metric_collect_enabled && m_frame_counter % m_metric_collect_opmon_rate == 0) {
+  m_frame_counter_for_metrics++;
+  if (m_tpg_metric_collect_enabled && m_frame_counter_for_metrics % m_metric_collect_opmon_rate == 0) {
     m_tp_generator->signal_metric_collection();
     m_update_metric_opmon.store(true, std::memory_order_release);
   }

--- a/src/wibeth/WIBEthFrameProcessor.cpp
+++ b/src/wibeth/WIBEthFrameProcessor.cpp
@@ -144,6 +144,9 @@ WIBEthFrameProcessor::conf(const appmodel::DataHandlerModule* conf)
           m_channel_mask_set.insert(off_channel);
       }
 
+      m_tpg_metric_collect_enabled = proc_conf->get_metric_collect_enable();
+      m_metric_collect_opmon_rate = proc_conf->get_metric_collect_opmon_rate();
+
       m_tp_generator->set_metric_collector_enable_state(m_tpg_metric_collect_enabled);
 
       m_tp_generator->configure(m_tpg_configs, m_channel_plane_numbers, types::DUNEWIBEthTypeAdapter::samples_tick_difference);
@@ -214,14 +217,10 @@ WIBEthFrameProcessor::generate_opmon_data()
      }
      m_t0 = now;
 
-    if (m_tpg_metric_collect_enabled) {
+     if (m_tpg_metric_collect_enabled && m_update_metric_opmon.load(std::memory_order_release)) {
+       auto metrics = m_tp_generator->get_processor_metrics();
+     }
 
-      if (m_tpg_metric_collect_counter++ % 128 == 0) { // FIXME: move to configurable interval
-        m_tp_generator->signal_metric_collection();
-        auto metrics = m_tp_generator->get_processor_metrics();
-      }
-
-    }
    }
    inherited::generate_opmon_data();
  }
@@ -374,6 +373,10 @@ WIBEthFrameProcessor::find_hits(constframeptr fp)
 
   std::vector<trgdataformats::TriggerPrimitive> tps = (*m_tp_generator)(wfptr);
   m_frame_counter++;
+  if (m_tpg_metric_collect_enabled && m_frame_counter % m_metric_collect_opmon_rate == 0) {
+    m_tp_generator->signal_metric_collection();
+    m_update_metric_opmon.store(true, std::memory_order_release);
+  }
 
   for (const auto& tp : tps) {
     // If this TP is on a masked channel, skip it.

--- a/src/wibeth/WIBEthFrameProcessor.cpp
+++ b/src/wibeth/WIBEthFrameProcessor.cpp
@@ -217,25 +217,28 @@ WIBEthFrameProcessor::generate_opmon_data()
      }
      m_t0 = now;
 
-     if (m_tpg_metric_collect_enabled) {
-       auto metrics = m_tp_generator->get_processor_metrics();
-
-       for (const auto& [channel, vec] : metrics) {
-        datahandlinglibs::opmon::TPGProcessorInfo tpg_proc_info;
-        for (const auto& [name, val] : vec) {
-          if (name == "m_pedestal") {
-            tpg_proc_info.set_pedestal(val);
-          } else if (name == "m_accum")
-          {
-            tpg_proc_info.set_accum(val);
-          }
-        }
-        publish(std::move(tpg_proc_info), {{"channel", std::to_string(channel)}});
-      }
-     }
+     publish_processor_metric_to_opmon();
 
    }
    inherited::generate_opmon_data();
+ }
+
+ void
+ WIBEthFrameProcessor::publish_processor_metric_to_opmon() {
+  if (m_tpg_metric_collect_enabled && m_tp_generator) {
+    auto metrics = m_tp_generator->get_processor_metrics();
+    for (const auto& [channel, vec] : metrics) {
+      datahandlinglibs::opmon::TPGProcessorInfo tpg_proc_info;
+      for (const auto& [name, val] : vec) {
+        if (name == "m_pedestal") {
+          tpg_proc_info.set_pedestal(val);
+        } else if (name == "m_accum") {
+          tpg_proc_info.set_accum(val);
+        }
+      }
+      publish(std::move(tpg_proc_info), {{"channel", std::to_string(channel)}});
+    }
+  }
  }
 
 
@@ -387,7 +390,7 @@ WIBEthFrameProcessor::find_hits(constframeptr fp)
   std::vector<trgdataformats::TriggerPrimitive> tps = (*m_tp_generator)(wfptr);
   m_frame_counter++;
   m_frame_counter_for_metrics++;
-  if (m_tpg_metric_collect_enabled && m_frame_counter_for_metrics % m_metric_collect_opmon_rate == 0) {
+  if (m_tpg_metric_collect_enabled && m_tp_generator && m_frame_counter_for_metrics % m_metric_collect_opmon_rate == 0) {
     m_tp_generator->signal_metric_collection();
     m_update_metric_opmon.store(true, std::memory_order_release);
   }

--- a/src/wibeth/WIBEthFrameProcessor.cpp
+++ b/src/wibeth/WIBEthFrameProcessor.cpp
@@ -70,6 +70,9 @@ WIBEthFrameProcessor::stop(const nlohmann::json& args)
 {
   inherited::stop(args);
   if (m_post_processing_enabled) {
+    if (m_tpg_metric_collect_enabled) {
+      m_tp_generator->free_metric_collector();
+    }
     // Clears the pipelines and resets with the given configs.
     m_tp_generator->configure(m_tpg_configs, m_channel_plane_numbers, types::DUNEWIBEthTypeAdapter::samples_tick_difference);
   }
@@ -207,6 +210,15 @@ WIBEthFrameProcessor::generate_opmon_data()
        el.second = 0;
      }
      m_t0 = now;
+
+    if (m_tpg_metric_collect_enabled) {
+
+      if (m_tpg_metric_collect_counter++ % 128 == 0) { // FIXME: move to configurable interval
+        m_tp_generator->signal_metric_collection();
+        auto metrics = m_tp_generator->get_processor_metrics();
+      }
+
+    }
    }
    inherited::generate_opmon_data();
  }

--- a/src/wibeth/WIBEthFrameProcessor.cpp
+++ b/src/wibeth/WIBEthFrameProcessor.cpp
@@ -74,6 +74,7 @@ WIBEthFrameProcessor::stop(const nlohmann::json& args)
       m_tp_generator->free_metric_collector();
     }
     // Clears the pipelines and resets with the given configs.
+    m_tp_generator->set_metric_collector_enable_state(m_tpg_metric_collect_enabled);
     m_tp_generator->configure(m_tpg_configs, m_channel_plane_numbers, types::DUNEWIBEthTypeAdapter::samples_tick_difference);
   }
 }
@@ -142,6 +143,8 @@ WIBEthFrameProcessor::conf(const appmodel::DataHandlerModule* conf)
         if (std::find(channel_mask_vec.begin(), channel_mask_vec.end(), off_channel) != channel_mask_vec.end())
           m_channel_mask_set.insert(off_channel);
       }
+
+      m_tp_generator->set_metric_collector_enable_state(m_tpg_metric_collect_enabled);
 
       m_tp_generator->configure(m_tpg_configs, m_channel_plane_numbers, types::DUNEWIBEthTypeAdapter::samples_tick_difference);
 

--- a/src/wibeth/WIBEthFrameProcessor.cpp
+++ b/src/wibeth/WIBEthFrameProcessor.cpp
@@ -217,30 +217,30 @@ WIBEthFrameProcessor::generate_opmon_data()
      }
      m_t0 = now;
 
-     publish_processor_metric_to_opmon();
-     publish_processor_metric_to_opmon_with_aggregation();
+     if (m_tpg_metric_collect_enabled && m_tp_generator) {
+       publish_processor_metric_to_opmon();
+       publish_processor_metric_to_opmon_with_aggregation();
+     }
    }
    
    inherited::generate_opmon_data();
  }
 
  void
- WIBEthFrameProcessor::publish_processor_metric_to_opmon() {
-  if (m_tpg_metric_collect_enabled && m_tp_generator) {
-    auto metrics = m_tp_generator->get_processor_metrics();
-    for (const auto& [channel, vec] : metrics) {
-      datahandlinglibs::opmon::TPGProcessorInfo tpg_proc_info;
-      for (const auto& [name, val] : vec) {
-        if (name == "m_pedestal") {
-          tpg_proc_info.set_pedestal(val);
-        } else if (name == "m_accum") {
-          tpg_proc_info.set_accum(val);
-        }
+WIBEthFrameProcessor::publish_processor_metric_to_opmon() {
+  auto metrics = m_tp_generator->get_processor_metrics();
+  for (const auto& [channel, vec] : metrics) {
+    datahandlinglibs::opmon::TPGProcessorInfo tpg_proc_info;
+    for (const auto& [name, val] : vec) {
+      if (name == "m_pedestal") {
+        tpg_proc_info.set_pedestal(val);
+      } else if (name == "m_accum") {
+        tpg_proc_info.set_accum(val);
       }
-      publish(std::move(tpg_proc_info), {{"channel", std::to_string(channel)}});
     }
+    publish(std::move(tpg_proc_info), {{"channel", std::to_string(channel)}});
   }
- }
+}
 
 std::map<int16_t, std::map<std::string, std::tuple<float, int16_t, int16_t, float, dunedaq::trgdataformats::channel_t, dunedaq::trgdataformats::channel_t>>> 
 WIBEthFrameProcessor::calculate_all_metric_summaries_across_planes(const std::unordered_map<dunedaq::trgdataformats::channel_t, std::vector<std::pair<std::string, int16_t>>>& metrics) {
@@ -308,26 +308,24 @@ WIBEthFrameProcessor::calculate_all_metric_summaries_across_planes(const std::un
 
 void
 WIBEthFrameProcessor::publish_processor_metric_to_opmon_with_aggregation() {
-  if (m_tpg_metric_collect_enabled && m_tp_generator) {
-    auto metrics = m_tp_generator->get_processor_metrics();
-    
-    // Use optimized single-pass calculation for all metrics across all planes
-    auto all_stats = calculate_all_metric_summaries_across_planes(metrics);
-    
-    // Publish all calculated statistics
-    for (const auto& [plane, metric_map] : all_stats) {
-      for (const auto& [metric_name, stats] : metric_map) {
-        const auto& [mean, min, max, stddev, min_channel_id, max_channel_id] = stats;
-        
-        datahandlinglibs::opmon::TPGProcessorReducedInfo info;
-        info.set_average(mean);
-        info.set_max(max);
-        info.set_min(min);
-        info.set_standard_dev(stddev);
-        info.set_max_channel_id(max_channel_id);
-        info.set_min_channel_id(min_channel_id);
-        publish(std::move(info), {{"plane", std::to_string(plane)}, {"metric", metric_name}});
-      }
+  auto metrics = m_tp_generator->get_processor_metrics();
+  
+  // Use optimized single-pass calculation for all metrics across all planes
+  auto all_stats = calculate_all_metric_summaries_across_planes(metrics);
+  
+  // Publish all calculated statistics
+  for (const auto& [plane, metric_map] : all_stats) {
+    for (const auto& [metric_name, stats] : metric_map) {
+      const auto& [mean, min, max, stddev, min_channel_id, max_channel_id] = stats;
+      
+      datahandlinglibs::opmon::TPGProcessorReducedInfo info;
+      info.set_average(mean);
+      info.set_max(max);
+      info.set_min(min);
+      info.set_standard_dev(stddev);
+      info.set_max_channel_id(max_channel_id);
+      info.set_min_channel_id(min_channel_id);
+      publish(std::move(info), {{"plane", std::to_string(plane)}, {"metric", metric_name}});
     }
   }
 }

--- a/src/wibeth/WIBEthFrameProcessor.cpp
+++ b/src/wibeth/WIBEthFrameProcessor.cpp
@@ -144,12 +144,15 @@ WIBEthFrameProcessor::conf(const appmodel::DataHandlerModule* conf)
           m_channel_mask_set.insert(off_channel);
       }
 
-      m_tpg_metric_collect_enabled = proc_conf->get_metric_collect_enable();
       m_metric_collect_opmon_period = proc_conf->get_metric_collect_opmon_rate();
 
-      m_tp_generator->set_metric_collector_enable_state(m_tpg_metric_collect_enabled);
+      // Let the TPG generator configure
 
       m_tp_generator->configure(m_tpg_configs, m_channel_plane_numbers, types::DUNEWIBEthTypeAdapter::samples_tick_difference);
+      
+      // After it sees the configs, it will set the metric collector enable state
+      
+      m_tpg_metric_collect_enabled = m_tp_generator->get_metric_collector_enable_state();
 
       inherited::add_postprocess_task(std::bind(&WIBEthFrameProcessor::find_hits, this, std::placeholders::_1));
     }

--- a/src/wibeth/WIBEthFrameProcessor.cpp
+++ b/src/wibeth/WIBEthFrameProcessor.cpp
@@ -311,7 +311,7 @@ WIBEthFrameProcessor::publish_processor_metric_to_opmon_with_aggregation() {
         dunedaq::trgdataformats::channel_t max_channel_id = 0;
         calculate_metric_summary_across_planes(metrics, metric_name, plane, mean, min, max, stddev, min_channel_id, max_channel_id);
         datahandlinglibs::opmon::TPGProcessorReducedInfo info;
-        info.set_mean(mean);
+        info.set_average(mean);
         info.set_max(max);
         info.set_min(min);
         info.set_standard_dev(stddev);


### PR DESCRIPTION
## Summary of Changes in fdreadoutlibs

Integrates processor metric collection `tpglibs` (https://github.com/DUNE-DAQ/tpglibs/pull/27) into `fdreadoutlibs`, enabling monitoring of TPG processor internal metrics through opmon.

### Key Changes:

**1. New Configurations**
- Added `metric_collect_enable` and `metric_collect_opmon_rate` configuration parameters in `TPCRawDataProcessor`, where the enable state should default to `false`.
- These parameters control whether processor metrics are collected and the rate at which they are polled from processors.

**2. WIBEthFrameProcessor Member Variables**
- Added member variables to track metric collection state:
  - `m_tpg_metric_collect_enabled` - controls metric collection
  - `m_metric_collect_opmon_rate` - controls publication frequency
  - `m_frame_counter_for_metrics` - tracks frame processing for rate limiting

**3. Metric Publication Methods**
- `publish_processor_metric_to_opmon()` - Publishes raw processor metrics (pedestal, accumulation values) per channel
- `publish_processor_metric_to_opmon_with_aggregation()` - Publishes aggregated metrics with statistical summaries across physical planes.
- `calculate_metric_summary_across_planes()` - Calculates mean, min, max, and standard deviation of metrics per plane