### PR TITLE
samples_to_tick converted to float

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(fdreadoutlibs VERSION 2.6.1)
+project(fdreadoutlibs VERSION 2.6.2)
 
 find_package(daq-cmake REQUIRED)
 

--- a/include/fdreadoutlibs/DUNEWIBEthTypeAdapter.hpp
+++ b/include/fdreadoutlibs/DUNEWIBEthTypeAdapter.hpp
@@ -92,7 +92,7 @@ struct DUNEWIBEthTypeAdapter
   static const constexpr daqdataformats::FragmentType fragment_type = daqdataformats::FragmentType::kWIBEth;
   static const constexpr uint64_t expected_tick_difference = 2048; // NOLINT(build/unsigned)
   static const constexpr uint64_t samples_per_frame = 64; // NOLINT(build/unsigned)
-  static const constexpr uint64_t samples_tick_difference = 32; // NOLINT(build/unsigned)
+  static const constexpr float samples_tick_difference = 32; // NOLINT(build/unsigned)
 };
 
 static_assert(sizeof(struct dunedaq::fddetdataformats::WIBEthFrame) == kDUNEWIBEthSize,

--- a/include/fdreadoutlibs/TDEEthTypeAdapter.hpp
+++ b/include/fdreadoutlibs/TDEEthTypeAdapter.hpp
@@ -95,7 +95,7 @@ struct TDEEthTypeAdapter
   static const constexpr uint64_t expected_tick_difference = 2000; // NOLINT(build/unsigned)
   static const constexpr uint64_t samples_per_frame = 64; // NOLINT(build/unsigned)
   // NOTE: this is actually 31.25
-  static const constexpr uint64_t samples_tick_difference = 32; // NOLINT(build/unsigned)
+  static const float uint64_t samples_tick_difference = 31.25; // NOLINT(build/unsigned)
 };
 
 static_assert(sizeof(struct dunedaq::fddetdataformats::TDEEthFrame) == kTDEEthSize,

--- a/include/fdreadoutlibs/TDEEthTypeAdapter.hpp
+++ b/include/fdreadoutlibs/TDEEthTypeAdapter.hpp
@@ -95,7 +95,7 @@ struct TDEEthTypeAdapter
   static const constexpr uint64_t expected_tick_difference = 2000; // NOLINT(build/unsigned)
   static const constexpr uint64_t samples_per_frame = 64; // NOLINT(build/unsigned)
   // NOTE: this is actually 31.25
-  static const float uint64_t samples_tick_difference = 31.25; // NOLINT(build/unsigned)
+  static const constexpr float samples_tick_difference = 31.25; // NOLINT(build/unsigned)
 };
 
 static_assert(sizeof(struct dunedaq::fddetdataformats::TDEEthFrame) == kTDEEthSize,


### PR DESCRIPTION
switch the samples tick difference to a float for the TDE type adapter.