### PR TITLE
Checking for a max number of frames or TPs before sending to sink

### DIFF
--- a/include/fdreadoutlibs/FDReadoutIssues.hpp
+++ b/include/fdreadoutlibs/FDReadoutIssues.hpp
@@ -31,6 +31,11 @@ ERS_DECLARE_ISSUE(fdreadoutlibs,
                   ((std::string)algorithm_selection))
 
 ERS_DECLARE_ISSUE(fdreadoutlibs,
+                  FrameAndTPCountersDisabled,
+                  "Both frame and TP counters are disabled. This means that in your configuration (TPCRawDataProcessor), both frame_count_limit and tp_count_limit are 0. At least one of the should be !0 ",
+                  ) 
+
+ERS_DECLARE_ISSUE(fdreadoutlibs,
                   TPTooLong,
                   "TP with SOT " << width << " for channel " << channel,
                   ((uint64_t)width) ((uint64_t)channel))
@@ -39,7 +44,6 @@ ERS_DECLARE_ISSUE(fdreadoutlibs,
                   FailedToSendTPVector,
                   "Failed to send TP vector beginning with start time " << s_ts_begin << " and channel number " << channel_begin << ", ending with start time " << s_ts_end << " and channel number " << channel_end,
                   ((dunedaq::daqdataformats::timestamp_t)s_ts_begin) ((uint64_t)channel_begin) ((dunedaq::daqdataformats::timestamp_t)s_ts_end) ((uint64_t)channel_end))
-
 
 ERS_DECLARE_ISSUE(fdreadoutlibs,
                   LinkMisconfiguration,

--- a/include/fdreadoutlibs/FDReadoutIssues.hpp
+++ b/include/fdreadoutlibs/FDReadoutIssues.hpp
@@ -32,7 +32,7 @@ ERS_DECLARE_ISSUE(fdreadoutlibs,
 
 ERS_DECLARE_ISSUE(fdreadoutlibs,
                   FrameAndTPCountersDisabled,
-                  "Both frame and TP counters are disabled. This means that in your configuration (TPCRawDataProcessor), both frame_count_limit and tp_count_limit are 0. At least one of the should be !0 ",
+                  "Both the frame and TP counters are currently disabled in your configuration (TPCRawDataProcessor), as both frame_count_limit and tp_count_limit are set to 0. Please enable at least one of these limits by setting it to a nonzero value to proceed.",
                   ) 
 
 ERS_DECLARE_ISSUE(fdreadoutlibs,

--- a/include/fdreadoutlibs/tde/TDEEthFrameProcessor.hpp
+++ b/include/fdreadoutlibs/tde/TDEEthFrameProcessor.hpp
@@ -143,6 +143,8 @@ private:
   uint32_t m_frame_count_limit = 0;
   size_t m_current_tp_count = 0;
   size_t m_current_frame_count = 0;
+  bool m_tp_limit_enabled = false;
+  bool m_frame_limit_enabled = false;
 
   std::shared_ptr<detchannelmaps::TPCChannelMap> m_channel_map;
 
@@ -162,7 +164,6 @@ private:
   std::atomic<uint64_t> m_new_tps{ 0 };  // NOLINT(build/unsigned)
   std::atomic<uint64_t> m_tps_suppressed_too_long{ 0 };
   std::atomic<uint64_t> m_tps_send_failed{ 0 };
-  std::atomic<uint64_t> m_frame_counter{ 0 };
 
   std::chrono::time_point<std::chrono::high_resolution_clock> m_t0;
 };

--- a/include/fdreadoutlibs/tde/TDEEthFrameProcessor.hpp
+++ b/include/fdreadoutlibs/tde/TDEEthFrameProcessor.hpp
@@ -139,6 +139,11 @@ private:
   uint32_t m_stream_id; // NOLINT(build/unsigned)
   bool m_emulator_mode = false;
 
+  uint32_t m_tp_count_limit = 0;
+  uint32_t m_frame_count_limit = 0;
+  size_t m_current_tp_count = 0;
+  size_t m_current_frame_count = 0;
+
   std::shared_ptr<detchannelmaps::TPCChannelMap> m_channel_map;
 
   // Mapping from expanded AVX register position to offline channel number

--- a/include/fdreadoutlibs/wibeth/WIBEthFrameProcessor.hpp
+++ b/include/fdreadoutlibs/wibeth/WIBEthFrameProcessor.hpp
@@ -162,6 +162,8 @@ private:
   uint32_t m_frame_count_limit = 0;
   size_t m_current_tp_count = 0;
   size_t m_current_frame_count = 0;
+  bool m_tp_limit_enabled = false;
+  bool m_frame_limit_enabled = false;
 
 
   std::shared_ptr<detchannelmaps::TPCChannelMap> m_channel_map;

--- a/include/fdreadoutlibs/wibeth/WIBEthFrameProcessor.hpp
+++ b/include/fdreadoutlibs/wibeth/WIBEthFrameProcessor.hpp
@@ -158,6 +158,11 @@ private:
   uint32_t m_stream_id; // NOLINT(build/unsigned)
   bool m_emulator_mode = false;
 
+
+  uint32_t m_TP_count_thr = 0;
+  uint32_t m_frame_count_thr = 0;
+  std::atomic<bool> m_TP_count_reached = false;//is this atomic an ovekill
+
   std::shared_ptr<detchannelmaps::TPCChannelMap> m_channel_map;
 
   // Mapping from expanded AVX register position to offline channel number
@@ -177,6 +182,12 @@ private:
   std::atomic<uint64_t> m_tps_suppressed_too_long{ 0 };
   std::atomic<uint64_t> m_tps_send_failed{ 0 };
   std::atomic<uint64_t> m_frame_counter{ 0 };
+
+
+  // how many plane do we actually have?? 
+  // m_TP_counter.store()
+  //do I need atomicity for the vector or for the variables of the vector? 
+
 
   std::chrono::time_point<std::chrono::high_resolution_clock> m_t0;
 };

--- a/include/fdreadoutlibs/wibeth/WIBEthFrameProcessor.hpp
+++ b/include/fdreadoutlibs/wibeth/WIBEthFrameProcessor.hpp
@@ -160,7 +160,7 @@ private:
 
   uint32_t m_TP_count_thr = 0;
   uint32_t m_frame_count_thr = 0;
-  std::atomic<bool> m_TP_count_reached = false;//is this atomic an ovekill
+  size_t m_current_tp_count=0;
 
   std::shared_ptr<detchannelmaps::TPCChannelMap> m_channel_map;
 

--- a/include/fdreadoutlibs/wibeth/WIBEthFrameProcessor.hpp
+++ b/include/fdreadoutlibs/wibeth/WIBEthFrameProcessor.hpp
@@ -158,9 +158,11 @@ private:
   bool m_emulator_mode = false;
 
 
-  uint32_t m_TP_count_thr = 0;
-  uint32_t m_frame_count_thr = 0;
-  size_t m_current_tp_count=0;
+  uint32_t m_tp_count_limit = 0;
+  uint32_t m_frame_count_limit = 0;
+  size_t m_current_tp_count = 0;
+  size_t m_current_frame_count = 0;
+
 
   std::shared_ptr<detchannelmaps::TPCChannelMap> m_channel_map;
 
@@ -181,7 +183,6 @@ private:
   std::atomic<uint64_t> m_tps_suppressed_too_long{ 0 };
   std::atomic<uint64_t> m_tps_send_failed{ 0 };
   std::atomic<uint64_t> m_frame_counter{ 0 };
-  std::atomic<uint64_t> m_frame_rel_counter{ 0 };
 
   std::chrono::time_point<std::chrono::high_resolution_clock> m_t0;
 };

--- a/include/fdreadoutlibs/wibeth/WIBEthFrameProcessor.hpp
+++ b/include/fdreadoutlibs/wibeth/WIBEthFrameProcessor.hpp
@@ -134,7 +134,6 @@ protected:
   void find_hits(constframeptr fp);
   //void find_hits(constframeptr fp);
 
-
 private:
   bool m_first_hit = true;
   bool m_tpg_metric_collect_enabled{false};
@@ -182,12 +181,7 @@ private:
   std::atomic<uint64_t> m_tps_suppressed_too_long{ 0 };
   std::atomic<uint64_t> m_tps_send_failed{ 0 };
   std::atomic<uint64_t> m_frame_counter{ 0 };
-
-
-  // how many plane do we actually have?? 
-  // m_TP_counter.store()
-  //do I need atomicity for the vector or for the variables of the vector? 
-
+  std::atomic<uint64_t> m_frame_rel_counter{ 0 };
 
   std::chrono::time_point<std::chrono::high_resolution_clock> m_t0;
 };

--- a/src/tde/TDEEthFrameProcessor.cpp
+++ b/src/tde/TDEEthFrameProcessor.cpp
@@ -113,6 +113,10 @@ TDEEthFrameProcessor::conf(const appmodel::DataHandlerModule* conf)
     if (proc_conf != nullptr && m_post_processing_enabled) {
       m_tp_generator = std::make_unique<tpglibs::TPGenerator>();
 
+      // Set the number of frames and TPs above which TPs are sent to sink.
+      m_tp_count_limit = proc_conf->get_tp_count_limit();
+      m_frame_count_limit = proc_conf->get_frame_count_limit();
+ 
       // Set the minimum TP samples over threshold.
       auto conf_sot_minima = proc_conf->get_sot_minima();
       std::vector<uint16_t> sot_minima{conf_sot_minima->get_sot_minimum_plane0(),
@@ -359,11 +363,12 @@ TDEEthFrameProcessor::find_hits(constframeptr fp)
 
   std::vector<trgdataformats::TriggerPrimitive> tps = (*m_tp_generator)(wfptr);
   m_frame_counter++;
-
+  m_current_frame_count++;
   for (const auto& tp : tps) {
     // If this TP is on a masked channel, skip it.
     if (std::binary_search(m_channel_mask_set.begin(), m_channel_mask_set.end(), tp.channel))
       continue;
+    m_current_tp_count++;
     // Need to move into a type adapter.
     trigger::TriggerPrimitiveTypeAdapter tpa;
     tpa.tp = tp;
@@ -373,7 +378,7 @@ TDEEthFrameProcessor::find_hits(constframeptr fp)
     m_tp_channel_rate_map[tp.channel]++;
   }
 
-  if (m_frame_counter >= 100) { // FIXME: Hard-coding 100 for now. This should be defined elsewhere or configurable.
+  if (m_current_frame_count > m_frame_count_limit || m_current_tp_count > m_tp_count_limit) {
     for (int i = 0; i < 3; i++) {
       int new_tps = m_tpa_vectors[i].size();
       if (new_tps == 0) {
@@ -392,6 +397,8 @@ TDEEthFrameProcessor::find_hits(constframeptr fp)
       }
     }
     m_frame_counter = 0;
+    m_current_tp_count=0;
+    m_current_frame_count = 0;
   }
 
   m_tpg_hits_count += nhits;

--- a/src/tde/TDEEthFrameProcessor.cpp
+++ b/src/tde/TDEEthFrameProcessor.cpp
@@ -120,7 +120,7 @@ TDEEthFrameProcessor::conf(const appmodel::DataHandlerModule* conf)
       m_tp_limit_enabled = m_tp_count_limit != 0;
 
       if (!m_frame_limit_enabled && !m_tp_limit_enabled){
-        ers::warning(FrameAndTPCountersDisabled(ERS_HERE));
+        ers::error(FrameAndTPCountersDisabled(ERS_HERE));
       }
  
       // Set the minimum TP samples over threshold.

--- a/src/tde/TDEEthFrameProcessor.cpp
+++ b/src/tde/TDEEthFrameProcessor.cpp
@@ -378,7 +378,7 @@ TDEEthFrameProcessor::find_hits(constframeptr fp)
     m_tp_channel_rate_map[tp.channel]++;
   }
 
-  if (m_current_frame_count > m_frame_count_limit || m_current_tp_count > m_tp_count_limit) {
+  if (m_current_frame_count >= m_frame_count_limit || (m_current_tp_count >= m_tp_count_limit && m_tp_count_limit !=0)) {
     for (int i = 0; i < 3; i++) {
       int new_tps = m_tpa_vectors[i].size();
       if (new_tps == 0) {

--- a/src/tde/TDEEthFrameProcessor.cpp
+++ b/src/tde/TDEEthFrameProcessor.cpp
@@ -114,8 +114,14 @@ TDEEthFrameProcessor::conf(const appmodel::DataHandlerModule* conf)
       m_tp_generator = std::make_unique<tpglibs::TPGenerator>();
 
       // Set the number of frames and TPs above which TPs are sent to sink.
-      m_tp_count_limit = proc_conf->get_tp_count_limit();
       m_frame_count_limit = proc_conf->get_frame_count_limit();
+      m_tp_count_limit = proc_conf->get_tp_count_limit();
+      m_frame_limit_enabled = m_frame_count_limit != 0;
+      m_tp_limit_enabled = m_tp_count_limit != 0;
+
+      if (!m_frame_limit_enabled && !m_tp_limit_enabled){
+        ers::warning(FrameAndTPCountersDisabled(ERS_HERE));
+      }
  
       // Set the minimum TP samples over threshold.
       auto conf_sot_minima = proc_conf->get_sot_minima();
@@ -362,7 +368,6 @@ TDEEthFrameProcessor::find_hits(constframeptr fp)
   }
 
   std::vector<trgdataformats::TriggerPrimitive> tps = (*m_tp_generator)(wfptr);
-  m_frame_counter++;
   m_current_frame_count++;
   for (const auto& tp : tps) {
     // If this TP is on a masked channel, skip it.
@@ -378,7 +383,10 @@ TDEEthFrameProcessor::find_hits(constframeptr fp)
     m_tp_channel_rate_map[tp.channel]++;
   }
 
-  if (m_current_frame_count >= m_frame_count_limit || (m_current_tp_count >= m_tp_count_limit && m_tp_count_limit !=0)) {
+  const bool frame_limit_reached = m_frame_limit_enabled && (m_current_frame_count >= m_frame_count_limit);
+  const bool tp_limit_reached = m_tp_limit_enabled && (m_current_tp_count >= m_tp_count_limit);
+
+  if (frame_limit_reached || tp_limit_reached){
     for (int i = 0; i < 3; i++) {
       int new_tps = m_tpa_vectors[i].size();
       if (new_tps == 0) {
@@ -396,7 +404,6 @@ TDEEthFrameProcessor::find_hits(constframeptr fp)
         nhits += new_tps;
       }
     }
-    m_frame_counter = 0;
     m_current_tp_count=0;
     m_current_frame_count = 0;
   }

--- a/src/wibeth/WIBEthFrameProcessor.cpp
+++ b/src/wibeth/WIBEthFrameProcessor.cpp
@@ -118,9 +118,15 @@ WIBEthFrameProcessor::conf(const appmodel::DataHandlerModule* conf)
       m_tp_generator = std::make_unique<tpglibs::TPGenerator>();
 
       // Set the number of frames and TPs above which TPs are sent to sink.
-      m_tp_count_limit = proc_conf->get_tp_count_limit();
       m_frame_count_limit = proc_conf->get_frame_count_limit();
+      m_tp_count_limit = proc_conf->get_tp_count_limit();
+      m_frame_limit_enabled = m_frame_count_limit != 0;
+      m_tp_limit_enabled = m_tp_count_limit != 0;
 
+      if (!m_frame_limit_enabled && !m_tp_limit_enabled){
+        ers::warning(FrameAndTPCountersDisabled(ERS_HERE));
+      }
+    
       // Set the minimum TP samples over threshold.
       auto conf_sot_minima = proc_conf->get_sot_minima();
       std::vector<uint16_t> sot_minima{conf_sot_minima->get_sot_minimum_plane0(),
@@ -503,7 +509,10 @@ WIBEthFrameProcessor::find_hits(constframeptr fp)
     m_tp_channel_rate_map[tp.channel]++;
   }
 
-  if (m_current_frame_count >= m_frame_count_limit || (m_current_tp_count >= m_tp_count_limit && m_tp_count_limit !=0)){
+  const bool frame_limit_reached = m_frame_limit_enabled && (m_current_frame_count >= m_frame_count_limit);
+  const bool tp_limit_reached = m_tp_limit_enabled && (m_current_tp_count >= m_tp_count_limit);
+
+  if (frame_limit_reached || tp_limit_reached){
     for (int i = 0; i < 3; i++) {// TO DO: the number of plane here is hard coded to 3. should this be configurable at a point?
       int new_tps = m_tpa_vectors[i].size();
       if (new_tps == 0) {

--- a/src/wibeth/WIBEthFrameProcessor.cpp
+++ b/src/wibeth/WIBEthFrameProcessor.cpp
@@ -117,10 +117,8 @@ WIBEthFrameProcessor::conf(const appmodel::DataHandlerModule* conf)
     if (proc_conf != nullptr && m_post_processing_enabled) {
       m_tp_generator = std::make_unique<tpglibs::TPGenerator>();
       //set the number of TP or frames after which the TPs are sent to the sink
-      m_TP_count_thr = proc_conf->get_TP_count_thr();
-      m_frame_count_thr = proc_conf->get_frame_count_thr();
-      TLOG()<< " m_TP_count_thr " << m_TP_count_thr;
-      TLOG()<< " m_frame_count_thr " << m_frame_count_thr; 
+      m_TP_count_thr = proc_conf->get_TP_count_limit();
+      m_frame_count_thr = proc_conf->get_frame_count_limit();
 
       // Set the minimum TP samples over threshold.
       auto conf_sot_minima = proc_conf->get_sot_minima();
@@ -500,23 +498,26 @@ WIBEthFrameProcessor::find_hits(constframeptr fp)
 
     tpa.tp.detid = m_det_id;  // Last missing piece.
     m_tpa_vectors[m_channel_map->get_plane_from_offline_channel(tp.channel)].push_back(tpa);
+    // if (m_frame_counter.load(std::memory_order_relaxed) < 100) TLOG() << "RMA DEBUG TP number" << m_tpa_vectors[m_channel_map->get_plane_from_offline_channel(tp.channel)].size();
     if (m_tpa_vectors[m_channel_map->get_plane_from_offline_channel(tp.channel)].size() % m_TP_count_thr == 0){
       m_TP_count_reached.store(true);
     }  
     m_tp_channel_rate_map[tp.channel]++;
   }
-  if (m_frame_counter.load(std::memory_order_relaxed) < 1000);// TLOG() << "RMA frame counter" <<m_frame_counter.load(std::memory_order_relaxed);
-  if (m_frame_counter.load(std::memory_order_relaxed) % m_frame_count_thr == 0) { // FIXME: Hard-coding 100 for now. This should be defined elsewhere or configurable.
+
+  if (m_frame_counter.load(std::memory_order_relaxed) % m_frame_count_thr == 0 || m_TP_count_reached.load(std::memory_order_relaxed)) {
     if (m_frame_counter.load(std::memory_order_relaxed) < 1000){
+      // TLOG() << "RMA DEBUG frame " << m_frame_counter.load(std::memory_order_relaxed) << " TP number "<< m_TP_count_reached.load(std::memory_order_relaxed);
       if (m_frame_counter.load(std::memory_order_relaxed) % m_frame_count_thr == 0){
-        // TLOG() << "RMA frame counter" <<m_frame_counter.load(std::memory_order_relaxed);
-      } else if(m_TP_count_reached) TLOG()<< "RMA TP counter";
+        TLOG()<< "RMA Frame counter reached";
+      } else if(m_TP_count_reached) TLOG()<< "RMA TP counter reached";
+    
     }
     for (int i = 0; i < 3; i++) {
       int new_tps = m_tpa_vectors[i].size();
       if (new_tps == 0) {
         continue;
-      }
+      } 
       const auto s_ts_begin = m_tpa_vectors[i].front().tp.time_start;
       const auto channel_begin = m_tpa_vectors[i].front().tp.channel;
       const auto s_ts_end = m_tpa_vectors[i].back().tp.time_start;

--- a/src/wibeth/WIBEthFrameProcessor.cpp
+++ b/src/wibeth/WIBEthFrameProcessor.cpp
@@ -505,7 +505,7 @@ WIBEthFrameProcessor::find_hits(constframeptr fp)
     }  
     m_tp_channel_rate_map[tp.channel]++;
   }
-  if (m_frame_counter.load(std::memory_order_relaxed) < 1000) TLOG() << "RMA frame counter" <<m_frame_counter.load(std::memory_order_relaxed);
+  if (m_frame_counter.load(std::memory_order_relaxed) < 1000);// TLOG() << "RMA frame counter" <<m_frame_counter.load(std::memory_order_relaxed);
   if (m_frame_counter.load(std::memory_order_relaxed) % m_frame_count_thr == 0) { // FIXME: Hard-coding 100 for now. This should be defined elsewhere or configurable.
     if (m_frame_counter.load(std::memory_order_relaxed) < 1000){
       if (m_frame_counter.load(std::memory_order_relaxed) % m_frame_count_thr == 0){

--- a/src/wibeth/WIBEthFrameProcessor.cpp
+++ b/src/wibeth/WIBEthFrameProcessor.cpp
@@ -485,7 +485,6 @@ WIBEthFrameProcessor::find_hits(constframeptr fp)
 
   std::vector<trgdataformats::TriggerPrimitive> tps = (*m_tp_generator)(wfptr);
   m_current_tp_count += tps.size();
-  m_frame_counter.fetch_add(1, std::memory_order_relaxed);
   m_current_frame_count++;
   if (m_tpg_metric_collect_enabled && m_frame_counter.load(std::memory_order_relaxed) % m_metric_collect_opmon_period == 0) {
     m_tp_generator->signal_metric_collection();
@@ -502,8 +501,8 @@ WIBEthFrameProcessor::find_hits(constframeptr fp)
     m_tpa_vectors[m_channel_map->get_plane_from_offline_channel(tp.channel)].push_back(tpa);
     m_tp_channel_rate_map[tp.channel]++;
   }
-  
-  if (m_current_frame_count < m_frame_count_limit || m_current_tp_count < m_tp_count_limit) {
+
+  if (m_current_frame_count > m_frame_count_limit || m_current_tp_count > m_tp_count_limit) {
     for (int i = 0; i < 3; i++) {
       int new_tps = m_tpa_vectors[i].size();
       if (new_tps == 0) {

--- a/src/wibeth/WIBEthFrameProcessor.cpp
+++ b/src/wibeth/WIBEthFrameProcessor.cpp
@@ -502,8 +502,7 @@ WIBEthFrameProcessor::find_hits(constframeptr fp)
     m_tp_channel_rate_map[tp.channel]++;
   }
 
-  // if (m_current_frame_count > m_frame_count_limit || m_current_tp_count > m_tp_count_limit) {
-  if (m_current_frame_count > m_frame_count_limit == 0 || m_current_tp_count > m_tp_count_limit) {
+  if (m_current_frame_count > m_frame_count_limit || m_current_tp_count > m_tp_count_limit) {
     for (int i = 0; i < 3; i++) {
       int new_tps = m_tpa_vectors[i].size();
       if (new_tps == 0) {

--- a/src/wibeth/WIBEthFrameProcessor.cpp
+++ b/src/wibeth/WIBEthFrameProcessor.cpp
@@ -484,6 +484,7 @@ WIBEthFrameProcessor::find_hits(constframeptr fp)
   }
 
   std::vector<trgdataformats::TriggerPrimitive> tps = (*m_tp_generator)(wfptr);
+  m_frame_counter.fetch_add(1, std::memory_order_relaxed);
   m_current_frame_count++;
   if (m_tpg_metric_collect_enabled && m_frame_counter.load(std::memory_order_relaxed) % m_metric_collect_opmon_period == 0) {
     m_tp_generator->signal_metric_collection();
@@ -503,7 +504,7 @@ WIBEthFrameProcessor::find_hits(constframeptr fp)
   }
 
   if (m_current_frame_count >= m_frame_count_limit || (m_current_tp_count >= m_tp_count_limit && m_tp_count_limit !=0)){
-    for (int i = 0; i < 3; i++) {
+    for (int i = 0; i < 3; i++) {// TO DO: the number of plane here is hard coded to 3. should this be configurable at a point?
       int new_tps = m_tpa_vectors[i].size();
       if (new_tps == 0) {
         continue;
@@ -520,7 +521,7 @@ WIBEthFrameProcessor::find_hits(constframeptr fp)
         nhits += new_tps;
       }
     }
-    m_current_tp_count=0;
+    m_current_tp_count = 0;
     m_current_frame_count = 0;
   }
   m_tpg_hits_count += nhits;

--- a/src/wibeth/WIBEthFrameProcessor.cpp
+++ b/src/wibeth/WIBEthFrameProcessor.cpp
@@ -502,7 +502,7 @@ WIBEthFrameProcessor::find_hits(constframeptr fp)
     m_tp_channel_rate_map[tp.channel]++;
   }
 
-  if (m_current_frame_count > m_frame_count_limit || m_current_tp_count > m_tp_count_limit) {
+  if (m_current_frame_count >= m_frame_count_limit || (m_current_tp_count >= m_tp_count_limit && m_tp_count_limit !=0)){
     for (int i = 0; i < 3; i++) {
       int new_tps = m_tpa_vectors[i].size();
       if (new_tps == 0) {

--- a/src/wibeth/WIBEthFrameProcessor.cpp
+++ b/src/wibeth/WIBEthFrameProcessor.cpp
@@ -116,9 +116,10 @@ WIBEthFrameProcessor::conf(const appmodel::DataHandlerModule* conf)
     auto proc_conf = dp->cast<appmodel::TPCRawDataProcessor>();
     if (proc_conf != nullptr && m_post_processing_enabled) {
       m_tp_generator = std::make_unique<tpglibs::TPGenerator>();
-      //set the number of TP or frames after which the TPs are sent to the sink
-      m_TP_count_thr = proc_conf->get_TP_count_limit();
-      m_frame_count_thr = proc_conf->get_frame_count_limit();
+
+      // Set the number of frames and TPs above which TPs are sent to sink.
+      m_TP_count_thr = proc_conf->get_TP_count_thr();
+      m_frame_count_thr = proc_conf->get_frame_count_thr();
 
       // Set the minimum TP samples over threshold.
       auto conf_sot_minima = proc_conf->get_sot_minima();
@@ -484,6 +485,7 @@ WIBEthFrameProcessor::find_hits(constframeptr fp)
 
   std::vector<trgdataformats::TriggerPrimitive> tps = (*m_tp_generator)(wfptr);
   m_frame_counter.fetch_add(1, std::memory_order_relaxed);
+  m_frame_rel_counter.fetch_add(1, std::memory_order_relaxed);
   if (m_tpg_metric_collect_enabled && m_frame_counter.load(std::memory_order_relaxed) % m_metric_collect_opmon_period == 0) {
     m_tp_generator->signal_metric_collection();
   }
@@ -498,21 +500,12 @@ WIBEthFrameProcessor::find_hits(constframeptr fp)
 
     tpa.tp.detid = m_det_id;  // Last missing piece.
     m_tpa_vectors[m_channel_map->get_plane_from_offline_channel(tp.channel)].push_back(tpa);
-    // if (m_frame_counter.load(std::memory_order_relaxed) < 100) TLOG() << "RMA DEBUG TP number" << m_tpa_vectors[m_channel_map->get_plane_from_offline_channel(tp.channel)].size();
     if (m_tpa_vectors[m_channel_map->get_plane_from_offline_channel(tp.channel)].size() % m_TP_count_thr == 0){
       m_TP_count_reached.store(true);
     }  
     m_tp_channel_rate_map[tp.channel]++;
   }
-
-  if (m_frame_counter.load(std::memory_order_relaxed) % m_frame_count_thr == 0 || m_TP_count_reached.load(std::memory_order_relaxed)) {
-    if (m_frame_counter.load(std::memory_order_relaxed) < 1000){
-      // TLOG() << "RMA DEBUG frame " << m_frame_counter.load(std::memory_order_relaxed) << " TP number "<< m_TP_count_reached.load(std::memory_order_relaxed);
-      if (m_frame_counter.load(std::memory_order_relaxed) % m_frame_count_thr == 0){
-        TLOG()<< "RMA Frame counter reached";
-      } else if(m_TP_count_reached) TLOG()<< "RMA TP counter reached";
-    
-    }
+  if (m_frame_rel_counter.load(std::memory_order_relaxed) % m_frame_count_thr == 0 || m_TP_count_reached.load(std::memory_order_relaxed)) {
     for (int i = 0; i < 3; i++) {
       int new_tps = m_tpa_vectors[i].size();
       if (new_tps == 0) {
@@ -530,9 +523,9 @@ WIBEthFrameProcessor::find_hits(constframeptr fp)
         nhits += new_tps;
       }
     }
+    m_TP_count_reached.store(false);
+    m_frame_rel_counter = 0;
   }
-
-  m_TP_count_reached.store(false);
   m_tpg_hits_count += nhits;
   return;
 }

--- a/src/wibeth/WIBEthFrameProcessor.cpp
+++ b/src/wibeth/WIBEthFrameProcessor.cpp
@@ -124,7 +124,7 @@ WIBEthFrameProcessor::conf(const appmodel::DataHandlerModule* conf)
       m_tp_limit_enabled = m_tp_count_limit != 0;
 
       if (!m_frame_limit_enabled && !m_tp_limit_enabled){
-        ers::warning(FrameAndTPCountersDisabled(ERS_HERE));
+        ers::error(FrameAndTPCountersDisabled(ERS_HERE));
       }
     
       // Set the minimum TP samples over threshold.

--- a/src/wibeth/WIBEthFrameProcessor.cpp
+++ b/src/wibeth/WIBEthFrameProcessor.cpp
@@ -484,6 +484,7 @@ WIBEthFrameProcessor::find_hits(constframeptr fp)
   }
 
   std::vector<trgdataformats::TriggerPrimitive> tps = (*m_tp_generator)(wfptr);
+  m_current_tp_count += tps.size();
   m_frame_counter.fetch_add(1, std::memory_order_relaxed);
   m_frame_rel_counter.fetch_add(1, std::memory_order_relaxed);
   if (m_tpg_metric_collect_enabled && m_frame_counter.load(std::memory_order_relaxed) % m_metric_collect_opmon_period == 0) {
@@ -497,15 +498,12 @@ WIBEthFrameProcessor::find_hits(constframeptr fp)
     // Need to move into a type adapter.
     trigger::TriggerPrimitiveTypeAdapter tpa;
     tpa.tp = tp;
-
     tpa.tp.detid = m_det_id;  // Last missing piece.
     m_tpa_vectors[m_channel_map->get_plane_from_offline_channel(tp.channel)].push_back(tpa);
-    if (m_tpa_vectors[m_channel_map->get_plane_from_offline_channel(tp.channel)].size() % m_TP_count_thr == 0){
-      m_TP_count_reached.store(true);
-    }  
     m_tp_channel_rate_map[tp.channel]++;
   }
-  if (m_frame_rel_counter.load(std::memory_order_relaxed) % m_frame_count_thr == 0 || m_TP_count_reached.load(std::memory_order_relaxed)) {
+  
+  if (m_frame_rel_counter.load(std::memory_order_relaxed) % m_frame_count_thr == 0 || sum < m_TP_count_thr) {
     for (int i = 0; i < 3; i++) {
       int new_tps = m_tpa_vectors[i].size();
       if (new_tps == 0) {
@@ -523,7 +521,7 @@ WIBEthFrameProcessor::find_hits(constframeptr fp)
         nhits += new_tps;
       }
     }
-    m_TP_count_reached.store(false);
+    m_current_tp_count=0;
     m_frame_rel_counter = 0;
   }
   m_tpg_hits_count += nhits;

--- a/src/wibeth/WIBEthFrameProcessor.cpp
+++ b/src/wibeth/WIBEthFrameProcessor.cpp
@@ -116,6 +116,11 @@ WIBEthFrameProcessor::conf(const appmodel::DataHandlerModule* conf)
     auto proc_conf = dp->cast<appmodel::TPCRawDataProcessor>();
     if (proc_conf != nullptr && m_post_processing_enabled) {
       m_tp_generator = std::make_unique<tpglibs::TPGenerator>();
+      //set the number of TP or frames after which the TPs are sent to the sink
+      m_TP_count_thr = proc_conf->get_TP_count_thr();
+      m_frame_count_thr = proc_conf->get_frame_count_thr();
+      TLOG()<< " m_TP_count_thr " << m_TP_count_thr;
+      TLOG()<< " m_frame_count_thr " << m_frame_count_thr; 
 
       // Set the minimum TP samples over threshold.
       auto conf_sot_minima = proc_conf->get_sot_minima();
@@ -495,10 +500,18 @@ WIBEthFrameProcessor::find_hits(constframeptr fp)
 
     tpa.tp.detid = m_det_id;  // Last missing piece.
     m_tpa_vectors[m_channel_map->get_plane_from_offline_channel(tp.channel)].push_back(tpa);
+    if (m_tpa_vectors[m_channel_map->get_plane_from_offline_channel(tp.channel)].size() % m_TP_count_thr == 0){
+      m_TP_count_reached.store(true);
+    }  
     m_tp_channel_rate_map[tp.channel]++;
   }
-
-  if (m_frame_counter.load(std::memory_order_relaxed) % 100 == 0) { // FIXME: Hard-coding 100 for now. This should be defined elsewhere or configurable.
+  if (m_frame_counter.load(std::memory_order_relaxed) < 1000) TLOG() << "RMA frame counter" <<m_frame_counter.load(std::memory_order_relaxed);
+  if (m_frame_counter.load(std::memory_order_relaxed) % m_frame_count_thr == 0) { // FIXME: Hard-coding 100 for now. This should be defined elsewhere or configurable.
+    if (m_frame_counter.load(std::memory_order_relaxed) < 1000){
+      if (m_frame_counter.load(std::memory_order_relaxed) % m_frame_count_thr == 0){
+        // TLOG() << "RMA frame counter" <<m_frame_counter.load(std::memory_order_relaxed);
+      } else if(m_TP_count_reached) TLOG()<< "RMA TP counter";
+    }
     for (int i = 0; i < 3; i++) {
       int new_tps = m_tpa_vectors[i].size();
       if (new_tps == 0) {
@@ -518,6 +531,7 @@ WIBEthFrameProcessor::find_hits(constframeptr fp)
     }
   }
 
+  m_TP_count_reached.store(false);
   m_tpg_hits_count += nhits;
   return;
 }

--- a/src/wibeth/WIBEthFrameProcessor.cpp
+++ b/src/wibeth/WIBEthFrameProcessor.cpp
@@ -484,7 +484,6 @@ WIBEthFrameProcessor::find_hits(constframeptr fp)
   }
 
   std::vector<trgdataformats::TriggerPrimitive> tps = (*m_tp_generator)(wfptr);
-  m_current_tp_count += tps.size();
   m_current_frame_count++;
   if (m_tpg_metric_collect_enabled && m_frame_counter.load(std::memory_order_relaxed) % m_metric_collect_opmon_period == 0) {
     m_tp_generator->signal_metric_collection();
@@ -494,6 +493,7 @@ WIBEthFrameProcessor::find_hits(constframeptr fp)
     // If this TP is on a masked channel, skip it.
     if (std::binary_search(m_channel_mask_set.begin(), m_channel_mask_set.end(), tp.channel))
       continue;
+    m_current_tp_count++;
     // Need to move into a type adapter.
     trigger::TriggerPrimitiveTypeAdapter tpa;
     tpa.tp = tp;
@@ -502,7 +502,8 @@ WIBEthFrameProcessor::find_hits(constframeptr fp)
     m_tp_channel_rate_map[tp.channel]++;
   }
 
-  if (m_current_frame_count > m_frame_count_limit || m_current_tp_count > m_tp_count_limit) {
+  // if (m_current_frame_count > m_frame_count_limit || m_current_tp_count > m_tp_count_limit) {
+  if (m_current_frame_count > m_frame_count_limit == 0 || m_current_tp_count > m_tp_count_limit) {
     for (int i = 0; i < 3; i++) {
       int new_tps = m_tpa_vectors[i].size();
       if (new_tps == 0) {

--- a/src/wibeth/WIBEthFrameProcessor.cpp
+++ b/src/wibeth/WIBEthFrameProcessor.cpp
@@ -118,8 +118,8 @@ WIBEthFrameProcessor::conf(const appmodel::DataHandlerModule* conf)
       m_tp_generator = std::make_unique<tpglibs::TPGenerator>();
 
       // Set the number of frames and TPs above which TPs are sent to sink.
-      m_TP_count_thr = proc_conf->get_TP_count_thr();
-      m_frame_count_thr = proc_conf->get_frame_count_thr();
+      m_tp_count_limit = proc_conf->get_tp_count_limit();
+      m_frame_count_limit = proc_conf->get_frame_count_limit();
 
       // Set the minimum TP samples over threshold.
       auto conf_sot_minima = proc_conf->get_sot_minima();
@@ -486,7 +486,7 @@ WIBEthFrameProcessor::find_hits(constframeptr fp)
   std::vector<trgdataformats::TriggerPrimitive> tps = (*m_tp_generator)(wfptr);
   m_current_tp_count += tps.size();
   m_frame_counter.fetch_add(1, std::memory_order_relaxed);
-  m_frame_rel_counter.fetch_add(1, std::memory_order_relaxed);
+  m_current_frame_count++;
   if (m_tpg_metric_collect_enabled && m_frame_counter.load(std::memory_order_relaxed) % m_metric_collect_opmon_period == 0) {
     m_tp_generator->signal_metric_collection();
   }
@@ -503,7 +503,7 @@ WIBEthFrameProcessor::find_hits(constframeptr fp)
     m_tp_channel_rate_map[tp.channel]++;
   }
   
-  if (m_frame_rel_counter.load(std::memory_order_relaxed) % m_frame_count_thr == 0 || sum < m_TP_count_thr) {
+  if (m_current_frame_count < m_frame_count_limit || m_current_tp_count < m_tp_count_limit) {
     for (int i = 0; i < 3; i++) {
       int new_tps = m_tpa_vectors[i].size();
       if (new_tps == 0) {
@@ -522,7 +522,7 @@ WIBEthFrameProcessor::find_hits(constframeptr fp)
       }
     }
     m_current_tp_count=0;
-    m_frame_rel_counter = 0;
+    m_current_frame_count = 0;
   }
   m_tpg_hits_count += nhits;
   return;


### PR DESCRIPTION
First step for the issue marked here: https://github.com/DUNE-DAQ/fdreadoutlibs/issues/260

This task could be divided into several subtasks: 

1. Introduce two configurable parameters: one sets the maximum number of frames (with a default of 100) and another sets the TP limit, after which the vector holding all TPs is dispatched to the sink.
2. One should find a more dynamical way to determine when TPs are sent to sink. For exampe monitor variables ikee TPs/10frames. 

In this PR I only deal with point 1. 

frame_count_limit -> defaulted at 100 as it was before.
tp_count_limit -> defaulted at at 210 TPs, 2x nominal TP count per dlh after 100 framse

Nominal TP count:

100 frames * 64 ticks / frame * 512 ns / tick ~> 3.28 ms
100 frames * 64 channels / frame * 32 TPs / channel ~> 204,800 TPs at the max rate or 62.5e6 TPs/s. 
The nominal TP rate per channel is around 500 Hz, so 32 kHz for a DLH. For the 100 frames, this is then (32kHz*3.28ms) ~105 TPs.

Code passed self-made consistency checks. As in testing if the values are well collected from the configuration, if the TPs are send to the sink when frame/tp condition met.

