### PR TITLE
[Feature]: Use  `TPGenerator::reset` Method

### DIFF
--- a/include/fdreadoutlibs/detail/TPCEthFrameProcessor.hxx
+++ b/include/fdreadoutlibs/detail/TPCEthFrameProcessor.hxx
@@ -295,7 +295,7 @@ TPCEthFrameProcessor<ReadoutTypeAdapter>::scrap_postprocessing()
   m_channel_plane_map.clear();
 
   // TP variables
-  m_tp_generator.reset(new tpglibs::TPGenerator());
+  m_tp_generator->reset();
   m_tpg_configs.clear();
   m_plane_to_tpa_vector_map.clear();
   m_plane_to_tp_sink_map.clear();


### PR DESCRIPTION
# Description
This is a linked PR to https://github.com/DUNE-DAQ/tpglibs/pull/36 that makes use of the new feature made available there. Details are available in that PR, including testing. The impact here is relatively small, but testing did point out the issue in https://github.com/DUNE-DAQ/datahandlinglibs/issues/110.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

