### PR TITLE
Gate TPG state harvester behind TPGLIBS_ENABLE_STATE_MONITORING, depr…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,9 @@ daq_add_application(tde_file_creator tde_file_creator.cxx TEST LINK_LIBRARIES fd
 daq_add_unit_test(DAPHNEStreamSuperChunkTypeAdapter_test LINK_LIBRARIES fdreadoutlibs)
 daq_add_unit_test(FDTypeAdaptersBuffers_test LINK_LIBRARIES fdreadoutlibs)
 daq_add_unit_test(FDReadoutRequestHandlers_test LINK_LIBRARIES fdreadoutlibs)
-daq_add_unit_test(TPGInternalStateHarvester_test LINK_LIBRARIES fdreadoutlibs)
+if(TPGLIBS_ENABLE_STATE_MONITORING)
+  daq_add_unit_test(TPGInternalStateHarvester_test LINK_LIBRARIES fdreadoutlibs)
+endif()
 
 ##############################################################################
 # Installation

--- a/include/fdreadoutlibs/FDReadoutIssues.hpp
+++ b/include/fdreadoutlibs/FDReadoutIssues.hpp
@@ -66,6 +66,27 @@ ERS_DECLARE_ISSUE(fdreadoutlibs,
                   PDSUnphysicalFrameTimestamp,
                   "PDS Frame with unphysical timestamp detected with ts=" << timestamp << ", ch=" << channel << ", sc_iframe=" << superchunk_iframe,
                   ((uint64_t)timestamp) ((uint64_t)channel) ((size_t)superchunk_iframe))
+ERS_DECLARE_ISSUE(fdreadoutlibs,
+                  TPGStateMonitoringDisabledAtBuildTime,
+                  "TPG state monitoring config flags are set but tpglibs was built with "
+                  "TPGLIBS_ENABLE_STATE_MONITORING=OFF. No processor metrics will be "
+                  "collected. Rebuild with -DTPGLIBS_ENABLE_STATE_MONITORING=ON to enable.",
+                  )
+
+ERS_DECLARE_ISSUE(fdreadoutlibs,
+                  TPGToggleStateDeprecated,
+                  "ProcessingStep attribute 'metric_collect_toggle_state' is set but this "
+                  "flag is deprecated. State monitoring is now controlled at build time via "
+                  "TPGLIBS_ENABLE_STATE_MONITORING. This attribute will be removed in a "
+                  "future release.",
+                  )
+
+ERS_DECLARE_ISSUE(fdreadoutlibs,
+                  TPGStateMonitoringConfigIgnored,
+                  "ProcessingStep attribute '" << attribute_name << "' is configured but "
+                  "has no effect because TPGLIBS_ENABLE_STATE_MONITORING=OFF.",
+                  ((std::string)attribute_name))
+
 } // namespace dunedaq
 
 #endif // FDREADOUTLIBS_INCLUDE_FDREADOUTLIBS_FDREADOUTISSUES_HPP_

--- a/include/fdreadoutlibs/TPCEthFrameProcessor.hpp
+++ b/include/fdreadoutlibs/TPCEthFrameProcessor.hpp
@@ -34,7 +34,9 @@
 #include "tpglibs/TPGenerator.hpp"
 #include "trigger/TriggerPrimitiveTypeAdapter.hpp"
 #include "trgdataformats/Types.hpp"
+#ifdef TPGLIBS_ENABLE_STATE_MONITORING
 #include "fdreadoutlibs/tpg/TPGInternalStateHarvester.hpp"
+#endif
 
 #include <algorithm>
 #include <atomic>
@@ -97,22 +99,12 @@ protected:
 
   void scrap_find_tps();
 
-  /**
-   * Publishes collected processor metrics to opmon, currently called in generate_opmon_data()
-   * */
+#ifdef TPGLIBS_ENABLE_STATE_MONITORING
   void publish_processor_metric_to_opmon();
-
-  /**
-   * Publishes collected processor metrics to opmon, with aggregation of metrics to summary statistics across physical planes
-   * */
   void publish_processor_metric_to_opmon_with_aggregation();
-
-  /**
-   * Optimized version that calculates all metric summaries across all planes in a single pass
-   * Returns a map of plane_number -> map of metric_name -> summary statistics
-   * */
   std::map<int16_t, std::map<std::string, std::tuple<float, int16_t, int16_t, float, dunedaq::trgdataformats::channel_t, dunedaq::trgdataformats::channel_t>>>
   calculate_all_metric_summaries_across_planes(const std::unordered_map<dunedaq::trgdataformats::channel_t, std::vector<std::pair<std::string, int16_t>>>& metrics);
+#endif
   /**
    * Pipeline Stage 1.: Check proper sequence id increments in DAQ Eth header
    * */
@@ -159,7 +151,9 @@ protected:
 
   // TPG related variables.
   std::unique_ptr<tpglibs::TPGenerator> m_tp_generator;
+#ifdef TPGLIBS_ENABLE_STATE_MONITORING
   std::unique_ptr<fdreadoutlibs::TPGInternalStateHarvester> m_state_harvester;
+#endif
   std::vector<std::pair<std::string, nlohmann::json>> m_tpg_configs;
 
   std::unordered_map<unsigned int, std::vector<trigger::TriggerPrimitiveTypeAdapter>> m_plane_to_tpa_vector_map;

--- a/include/fdreadoutlibs/detail/TPCEthFrameProcessor.hxx
+++ b/include/fdreadoutlibs/detail/TPCEthFrameProcessor.hxx
@@ -42,10 +42,11 @@ TPCEthFrameProcessor<ReadoutTypeAdapter>::start(const appfwk::DAQModule::Command
   m_num_new_tps.exchange(0);
 
       
-  // Start the state harvester collection thread if enabled
+#ifdef TPGLIBS_ENABLE_STATE_MONITORING
   if (m_state_harvester && m_tpg_metric_collect_enabled) {
     m_state_harvester->start_collection_thread();
   }
+#endif
   inherited::start(args);
 }
 
@@ -55,10 +56,11 @@ TPCEthFrameProcessor<ReadoutTypeAdapter>::stop(const appfwk::DAQModule::CommandD
 { 
   inherited::stop(args);
   if (this->m_post_processing_enabled) {
-    // Stop the state harvester collection thread if it exists
+#ifdef TPGLIBS_ENABLE_STATE_MONITORING
     if (m_state_harvester) {
       m_state_harvester->stop_collection_thread();
     }
+#endif
     // Clears the pipelines and resets with the given configs.
     m_tp_generator->configure(m_tpg_configs, m_channel_plane_numbers, ReadoutTypeAdapter::samples_tick_difference);
   }
@@ -169,17 +171,27 @@ TPCEthFrameProcessor<ReadoutTypeAdapter>::configure_find_tps(const appmodel::Dat
 
   m_metric_collect_opmon_period = proc_conf->get_metric_collect_opmon_period();
 
-  // Check if metric collection is enabled in the configs
+  // In ALL builds: warn if obsolete metric_collect_toggle_state is set
+  for (const auto& name_config : m_tpg_configs) {
+    if (name_config.second.contains("metric_collect_toggle_state") &&
+        name_config.second["metric_collect_toggle_state"] == true) {
+      ers::warning(TPGToggleStateDeprecated(ERS_HERE));
+      break;
+    }
+  }
+
+#ifdef TPGLIBS_ENABLE_STATE_MONITORING
+  // Monitoring enabled at build time — set up harvester
+  // Still read toggle_state for backwards compat (honor it for now)
   m_tpg_metric_collect_enabled = false;
   for (const auto& name_config : m_tpg_configs) {
-    if (name_config.second.contains("metric_collect_toggle_state") && 
+    if (name_config.second.contains("metric_collect_toggle_state") &&
         name_config.second["metric_collect_toggle_state"] == true) {
       m_tpg_metric_collect_enabled = true;
       break;
     }
   }
 
-  // Only create and configure state harvester if metric collection is enabled
   if (m_tpg_metric_collect_enabled) {
     auto processsor_references = m_tp_generator->get_all_processor_references_with_pipeline_index();
 
@@ -187,20 +199,47 @@ TPCEthFrameProcessor<ReadoutTypeAdapter>::configure_find_tps(const appmodel::Dat
 
     const uint8_t channels_per_pipeline = 16;
     const uint8_t pipelines = static_cast<uint8_t>(m_channel_plane_numbers.size() / channels_per_pipeline);
-    
-    TLOG_DEBUG(TLVL_BOOKKEEPING) << "Configuring state harvester with " << static_cast<int>(channels_per_pipeline) 
-                                  << " channels per pipeline, " << static_cast<int>(pipelines) << " pipelines, " 
+
+    TLOG_DEBUG(TLVL_BOOKKEEPING) << "Configuring state harvester with " << static_cast<int>(channels_per_pipeline)
+                                  << " channels per pipeline, " << static_cast<int>(pipelines) << " pipelines, "
                                   << processsor_references.size() << " processor references";
-    
+
     m_state_harvester->update_channel_plane_numbers(m_channel_plane_numbers,
                                                     channels_per_pipeline, pipelines);
     m_state_harvester->set_processor_references(processsor_references);
-    
-    // Start the collection thread immediately after configuration
+
     m_state_harvester->start_collection_thread();
-    
+
     TLOG_DEBUG(TLVL_BOOKKEEPING) << "State harvester configured and started successfully";
   }
+
+#else
+  // Monitoring disabled at build time
+  m_tpg_metric_collect_enabled = false;
+
+  // Warn if per-processor monitoring params are configured but will have no effect
+  bool warned_build_off = false;
+  for (const auto& name_config : m_tpg_configs) {
+    if (name_config.second.contains("metric_collect_time_sample_period") &&
+        name_config.second["metric_collect_time_sample_period"] != 256) {
+      if (!warned_build_off) {
+        ers::warning(TPGStateMonitoringDisabledAtBuildTime(ERS_HERE));
+        warned_build_off = true;
+      }
+      ers::warning(TPGStateMonitoringConfigIgnored(ERS_HERE,
+                   "metric_collect_time_sample_period"));
+    }
+    if (name_config.second.contains("requested_internal_states") &&
+        !name_config.second["requested_internal_states"].get<std::string>().empty()) {
+      if (!warned_build_off) {
+        ers::warning(TPGStateMonitoringDisabledAtBuildTime(ERS_HERE));
+        warned_build_off = true;
+      }
+      ers::warning(TPGStateMonitoringConfigIgnored(ERS_HERE,
+                   "requested_internal_states"));
+    }
+  }
+#endif
 
   inherited::add_postprocess_task(std::bind(&TPCEthFrameProcessor<ReadoutTypeAdapter>::find_tps, this, std::placeholders::_1));
 }
@@ -392,15 +431,18 @@ TPCEthFrameProcessor<ReadoutTypeAdapter>::generate_opmon_data()
      }
      m_t0 = now;
 
+#ifdef TPGLIBS_ENABLE_STATE_MONITORING
     if (m_tpg_metric_collect_enabled && m_state_harvester) {
       publish_processor_metric_to_opmon();
       publish_processor_metric_to_opmon_with_aggregation();
     }
+#endif
    }
 
    inherited::generate_opmon_data();
  }
 
+#ifdef TPGLIBS_ENABLE_STATE_MONITORING
 template <class ReadoutTypeAdapter>
 void
 TPCEthFrameProcessor<ReadoutTypeAdapter>::publish_processor_metric_to_opmon() {
@@ -535,6 +577,7 @@ TPCEthFrameProcessor<ReadoutTypeAdapter>::publish_processor_metric_to_opmon_with
     }
   }
 }
+#endif // TPGLIBS_ENABLE_STATE_MONITORING
 
 
 /**
@@ -656,11 +699,12 @@ TPCEthFrameProcessor<ReadoutTypeAdapter>::find_tps(constframeptr fp)
 
   uint64_t current_frame_count = m_frame_counter.fetch_add(1, std::memory_order_relaxed) + 1;
   
-  // Trigger asynchronous metric collection in background thread
-  if (m_tpg_metric_collect_enabled && m_state_harvester && 
+#ifdef TPGLIBS_ENABLE_STATE_MONITORING
+  if (m_tpg_metric_collect_enabled && m_state_harvester &&
       current_frame_count % m_metric_collect_opmon_period == 0) {
     m_state_harvester->trigger_harvest();
   }
+#endif
 
   for (const auto& tp : tps) {
     // If this TP is on a masked channel, skip it.

--- a/src/tpg/TPGInternalStateHarvester.cpp
+++ b/src/tpg/TPGInternalStateHarvester.cpp
@@ -5,6 +5,7 @@
  * Licensing/copyright details are in the COPYING file that you should have
  * received with this code.
  */
+#ifdef TPGLIBS_ENABLE_STATE_MONITORING
 #include "fdreadoutlibs/tpg/TPGInternalStateHarvester.hpp"
 #include "datahandlinglibs/ReadoutLogging.hpp"
 #include "logging/Logging.hpp"
@@ -279,3 +280,4 @@ void TPGInternalStateHarvester::collection_thread_worker_() {
 
 } // namespace fdreadoutlibs
 } // namespace dunedaq
+#endif // TPGLIBS_ENABLE_STATE_MONITORING

--- a/unittest/TPGInternalStateHarvester_test.cxx
+++ b/unittest/TPGInternalStateHarvester_test.cxx
@@ -6,6 +6,8 @@
  * received with this code.
  */
 
+#ifdef TPGLIBS_ENABLE_STATE_MONITORING
+
 #include "fdreadoutlibs/tpg/TPGInternalStateHarvester.hpp"
 #include "tpglibs/AbstractProcessor.hpp"
 #include "tpglibs/ProcessorMetricArray.hpp"
@@ -713,3 +715,5 @@ BOOST_AUTO_TEST_CASE(ZeroValueCollection)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+
+#endif // TPGLIBS_ENABLE_STATE_MONITORING


### PR DESCRIPTION
Gate TPG state harvester behind TPGLIBS_ENABLE_STATE_MONITORING; Deprecate metric_collect_toggle_state with a silent ignore ERS warning.

# Description

Addresses issue #https://github.com/DUNE-DAQ/tpglibs/issues/39

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`) (tpg_state_collection test fails due to new ERS warning unexpected. Will be fixed.
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

Test in progress.

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

